### PR TITLE
Add Cloze one by one and fix bugs

### DIFF
--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -16,9 +16,6 @@
 
   var ScrollToButton = true;
 
-  // ##############  TAG SHORTCUT  ##############
-  var toggleTagsShortcut = "C";
-
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,14 +1,12 @@
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
-  // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-  // The shortcuts are  Alt  +  the number/letter below
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
   var ButtonShortcuts = {
-    "Personal Notes": '49', // alt + 1
-    "Missed Questions": '50', // alt + 2
+    "Personal Notes": "Alt + 1",
+    "Missed Questions": "Alt + 2",
   }
 
-  var ToggleAllButtons = '222' // '
+  var ToggleAllButtonsShortcut = "'"
 
   // ##############  SHOW HINTS AUTOMATICALLY  ##############
   var ButtonAutoReveal = {
@@ -19,8 +17,7 @@
   var ScrollToButton = true;
 
   // ##############  TAG SHORTCUT  ##############
-  // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-  var ToggleTags = "67"; // c
+  var ToggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -53,10 +50,57 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 
-
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
-  
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
   
 <!-- TOGGLE BUTTONS -->
 <script>
@@ -116,11 +160,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           this.toggle()
         }
 
+        var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+        var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
         document.addEventListener("keydown", (evt) => {
-          if (evt.repeat) return
-          if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-          if (evt.keyCode == ToggleAllButtons) this.toggle()
-          return false
+            if (evt.repeat) return
+            if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+              this.toggle()
+            }
+            return false
         })
       }
 
@@ -200,12 +247,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         "none";
     }
   }
+  
+  var isShortcut = shortcutMatcher(ToggleTagsShortcut)
   document.addEventListener('keyup', function (e) {
-    if (e.keyCode == ToggleTags) {
-      showtags();
-    }
+      if (isShortcut(e)) {
+          showtags();
+      }
   });
-
 
 </script>
 {{/Tags}}

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -165,7 +165,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
 
         // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-        setInnerHTML(this.hint, content)
+        ankingsetInnerHTML(this.hint, content)
 
 
         this.button.onclick = () => this.toggle()
@@ -216,7 +216,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
   defineHintButton()
 
-  function setInnerHTML(elm, html) {
+  function ankingsetInnerHTML(elm, html) {
     elm.innerHTML = html;
     Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
       const newScript = document.createElement("script");

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -51,6 +51,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -159,7 +179,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
         var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
         var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-        document.addEventListener("keydown", (evt) => {
+        ankingAddEventListener(document, "keydown", (evt) => {
             if (evt.repeat) return
             if (isShortcut(evt) || isToggleAllShortcut(evt)) {
               this.toggle()
@@ -246,7 +266,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   }
   
   var isShortcut = shortcutMatcher(toggleTagsShortcut)
-  document.addEventListener('keyup', function (e) {
+  ankingAddEventListener(document, 'keyup', function (e) {
       if (isShortcut(e)) {
           showtags();
       }
@@ -408,14 +428,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   }
   var pcc = document.getElementById("popup-container");
   var prevSel = "";
-  document.addEventListener('click', function () {
+  ankingAddEventListener(document, 'click', function () {
     var currentSelection = getSelectionText();
     if (currentSelection !== "") { prevSel = currentSelection; }
     if (currentSelection && !mustClickW) {
       getSummaryFor(currentSelection);
     } else { closePopup(); }
   });
-  document.addEventListener('keyup', function (e) {
+  ankingAddEventListener(document, 'keyup', function (e) {
     if (e.key == "w") {
       if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
     }

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -17,7 +17,7 @@
   var ScrollToButton = true;
 
   // ##############  TAG SHORTCUT  ##############
-  var ToggleTagsShortcut = "C";
+  var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -248,7 +248,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
   }
   
-  var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+  var isShortcut = shortcutMatcher(toggleTagsShortcut)
   document.addEventListener('keyup', function (e) {
       if (isShortcut(e)) {
           showtags();

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -95,7 +95,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -16,6 +16,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -25,6 +25,52 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     // ############## USER CONFIGURATION END ##############
 </script>
 
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 <!-- COUNTDOWN TIMER -->
 <div class="timer" id="s2"></div>
@@ -97,8 +143,9 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
-    document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+    var isShortcut = matchShortcut(toggleTagsShortcut)
+    documentr.addEventListener('keyup', function (e) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -25,6 +25,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     // ############## USER CONFIGURATION END ##############
 </script>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -144,7 +164,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     var isShortcut = matchShortcut(toggleTagsShortcut)
-    documentr.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -19,7 +19,7 @@
   var ScrollToButton = true;
 
   // ##############  TAG SHORTCUT  ##############
-  var ToggleTagsShortcut = "C";
+  var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -255,7 +255,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
   }
 
-  var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+  var isShortcut = shortcutMatcher(toggleTagsShortcut)
   document.addEventListener('keyup', function (e) {
       if (isShortcut(e)) {
           showtags();

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -172,7 +172,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
 
         // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-        setInnerHTML(this.hint, content)
+        ankingsetInnerHTML(this.hint, content)
 
 
         this.button.onclick = () => this.toggle()
@@ -223,7 +223,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
   defineHintButton()
 
-  function setInnerHTML(elm, html) {
+  function ankingsetInnerHTML(elm, html) {
     elm.innerHTML = html;
     Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
       const newScript = document.createElement("script");

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,15 +1,13 @@
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
-  // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-  // The shortcuts are  Alt  +  the number/letter below
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
   var ButtonShortcuts = {
-    "Definitions": '49', // alt + 1
-    "Examples": '50', // alt + 2
-    "Alternative Translations": '51', // alt + 3
+    "Definitions": "Alt + 1",
+    "Examples": "Alt + 2",
+    "Alternative Translations": "Alt + 3"
   }
 
-  var ToggleAllButtons = '222' // '
+  var ToggleAllButtonsShortcut = "'"
 
   // ##############  SHOW HINTS AUTOMATICALLY  ##############
   var ButtonAutoReveal = {
@@ -21,8 +19,7 @@
   var ScrollToButton = true;
 
   // ##############  TAG SHORTCUT  ##############
-  // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-  var ToggleTags = "67"; // c
+  var ToggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -62,6 +59,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 
 <!-- TOGGLE BUTTONS -->
@@ -122,11 +167,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           this.toggle()
         }
 
+        var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+        var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
         document.addEventListener("keydown", (evt) => {
-          if (evt.repeat) return
-          if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-          if (evt.keyCode == ToggleAllButtons) this.toggle()
-          return false
+            if (evt.repeat) return
+            if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+              this.toggle()
+            }
+            return false
         })
       }
 
@@ -206,13 +254,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         "none";
     }
   }
+
+  var isShortcut = shortcutMatcher(ToggleTagsShortcut)
   document.addEventListener('keyup', function (e) {
-    if (e.keyCode == ToggleTags) {
-      showtags();
-    }
+      if (isShortcut(e)) {
+          showtags();
+      }
   });
-
-
 </script>
 {{/Tags}}
 

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -58,6 +58,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -166,7 +186,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
         var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
         var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-        document.addEventListener("keydown", (evt) => {
+        ankingAddEventListener(document, "keydown", (evt) => {
             if (evt.repeat) return
             if (isShortcut(evt) || isToggleAllShortcut(evt)) {
               this.toggle()
@@ -253,7 +273,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   }
 
   var isShortcut = shortcutMatcher(toggleTagsShortcut)
-  document.addEventListener('keyup', function (e) {
+  ankingAddEventListener(document, 'keyup', function (e) {
       if (isShortcut(e)) {
           showtags();
       }
@@ -414,14 +434,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   }
   var pcc = document.getElementById("popup-container");
   var prevSel = "";
-  document.addEventListener('click', function () {
+  ankingAddEventListener(document, 'click', function () {
     var currentSelection = getSelectionText();
     if (currentSelection !== "") { prevSel = currentSelection; }
     if (currentSelection && !mustClickW) {
       getSummaryFor(currentSelection);
     } else { closePopup(); }
   });
-  document.addEventListener('keyup', function (e) {
+  ankingAddEventListener(document, 'keyup', function (e) {
     if (e.key == "w") {
       if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
     }

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -18,9 +18,6 @@
 
   var ScrollToButton = true;
 
-  // ##############  TAG SHORTCUT  ##############
-  var toggleTagsShortcut = "C";
-
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -26,6 +26,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
 <!-- COUNTDOWN TIMER -->
 <div class="timer" id="s2"></div>
 <script>
@@ -97,8 +145,10 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -95,7 +95,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -16,6 +16,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -26,6 +26,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -147,7 +167,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
     }
 
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -20,9 +20,6 @@
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C";
-
     // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
     var revealClozeShortcut = "N" // Shortcut to reveal next cloze
     var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -23,6 +23,29 @@
     // ##############  TAG SHORTCUT  ##############
     var ToggleTagsShortcut = "C";
 
+    // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
+    var revealClozeShortcut = "N" // Shortcut to reveal next cloze
+    var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
+
+    // Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+    // "word" reveals word by word. 
+    var revealNextClozeMode = "cloze" 
+
+    // What cloze is hidden with
+    var clozeHider = (elem) => "👑"
+    /* 
+    You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
+
+    // Fixed length:
+    var clozeHider = (elem) => "███"
+    // Replace each character with "█":
+    var clozeHider = (elem) => "█".repeat(elem.textContent.length)
+    // Show whitespaces:
+    var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
+    // Color-filled box (doesn't hide images):
+    var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+    */
+
 </script>
 
 <div class="clozefield" id="text">{{cloze:Text}}</div>
@@ -297,7 +320,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -21,7 +21,7 @@
     var tagID = "XXXYYYZZZ"
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
     var revealClozeShortcut = "N" // Shortcut to reveal next cloze
@@ -446,7 +446,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
         if (isShortcut(e)) {
             showtags();

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -90,6 +90,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -198,7 +218,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                       this.toggle()
@@ -334,8 +354,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -397,7 +417,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -444,7 +464,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }
@@ -607,14 +627,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
     var pcc = document.getElementById("popup-container");
     var prevSel = "";
-    document.addEventListener('click', function () {
+    ankingAddEventListener(document, 'click', function () {
         var currentSelection = getSelectionText();
         if (currentSelection !== "") { prevSel = currentSelection; }
         if (currentSelection && !mustClickW) {
             getSummaryFor(currentSelection);
         } else { closePopup(); }
     });
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (e.key == "w") {
             if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
         }

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -204,7 +204,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -255,7 +255,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -1,14 +1,12 @@
  <script>
     // ##############  HINT REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Personal Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
+        "Personal Notes" : "Alt + 1",
+        "Missed Questions" : "Alt + 2"
     }
 
-    var ToggleAllButtons = '222' // '
+    var ToggleAllButtonsShortcut = "'"
 
     // ##############  SHOW HINTS AUTOMATICALLY  ##############
     var ButtonAutoReveal = {
@@ -23,8 +21,7 @@
     var tagID = "XXXYYYZZZ"
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
 </script>
 
@@ -63,6 +60,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 
 <!-- TOGGLE BUTTONS -->
@@ -123,10 +168,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                      this.toggle()
+                    }
                     return false
                 })
             }
@@ -207,12 +255,12 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });
-
 
 </script>
 {{/Tags}}

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -69,6 +69,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 <!-- BUTTON FIELDS -->
+
+<!-- ClOZE ONE BY ONE BUTTONS -->
+{{#One by one}}
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
+<br />
+{{/One by one}}
+
 {{#Personal Notes}}<hint-button field-name="Personal Notes" short="ln" hint-id="notes"></hint-button>
 <div id="dummy-ln" style="display: none;">{{edit:Personal Notes}}</div>{{/Personal Notes}}
 

--- a/Note Types/Cloze-AnKing/Back Template.html
+++ b/Note Types/Cloze-AnKing/Back Template.html
@@ -222,6 +222,166 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
+<script>
+  (function() {
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
+    } catch (exception) {
+      console.log(exception)
+    }
+
+    const hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    const revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
+    }
+
+    const revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
+      }
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    const hideloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    const attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
+</script>
+
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>

--- a/Note Types/Cloze-AnKing/Front Template.html
+++ b/Note Types/Cloze-AnKing/Front Template.html
@@ -16,6 +16,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Cloze-AnKing/Front Template.html
+++ b/Note Types/Cloze-AnKing/Front Template.html
@@ -26,6 +26,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
 <!-- COUNTDOWN TIMER -->
 <div class="timer" id="s2"></div>
 <script>
@@ -91,8 +139,10 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKing/Front Template.html
+++ b/Note Types/Cloze-AnKing/Front Template.html
@@ -89,7 +89,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKing/Front Template.html
+++ b/Note Types/Cloze-AnKing/Front Template.html
@@ -26,6 +26,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -73,6 +93,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     return matchShortcut
   }
 </script>
+
 
 <!-- COUNTDOWN TIMER -->
 <div class="timer" id="s2"></div>
@@ -141,7 +162,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
     }
 
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -20,7 +20,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -460,7 +460,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         } 
 
-        var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+        var isShortcut = shortcutMatcher(toggleTagsShortcut)
         document.addEventListener('keyup', function (e) {
             if (isShortcut(e)) {
                 showtags();

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -219,7 +219,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -270,7 +270,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -19,9 +19,6 @@
 
     var ScrollToButton = true;
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C";
-
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -1,15 +1,13 @@
 <script>
     // ##############  HINT REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Personal Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
-        "Textbook" : '51', // alt + 3
-        "Additional Resources" : '52', // alt + 4
+        "Personal Notes" : "Alt + 1",
+        "Missed Questions" : "Alt + 2",
+        "Textbook" : "Alt + 3",
+        "Additional Resources" : "Alt + 4",
     }
-    var ToggleAllButtons = '222' // '
+    var ToggleAllButtonsShortcut = "'"
 
     // ##############  SHOW HINTS AUTOMATICALLY  ##############
     var ButtonAutoReveal = {
@@ -22,8 +20,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -77,6 +74,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 
 <!-- TOGGLE BUTTONS -->
@@ -137,10 +182,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                      this.toggle()
+                    }
                     return false
                 })
             }
@@ -221,11 +269,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           "none";
           }
         } 
-        document.addEventListener('keyup', function(e) {
-            if(e.keyCode == ToggleTags){
-             showtags();
+
+        var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+        document.addEventListener('keyup', function (e) {
+            if (isShortcut(e)) {
+                showtags();
             }
         });
+
         
         
     </script>

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -74,6 +74,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 <!-- BUTTON FIELDS -->
+
+<!-- ClOZE ONE BY ONE BUTTONS -->
+{{#One by one}}
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
+<br />
+{{/One by one}}
+
 {{#Personal Notes}}<hint-button field-name="Personal Notes" short="ln" hint-id="notes"></hint-button>
 <div id="dummy-ln" style="display: none;">{{edit:Personal Notes}}</div>{{/Personal Notes}}
 

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -236,6 +236,165 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
+<script>
+  (function() {
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
+    } catch (exception) {
+      console.log(exception)
+    }
+
+    const hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    const revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
+    }
+
+    const revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
+      }
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    const hideloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    const attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
+</script>
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
     <div id="tags-container">{{clickable::Tags}}</div>

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -25,6 +25,29 @@
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 
+    // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
+    var revealClozeShortcut = "N" // Shortcut to reveal next cloze
+    var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
+
+    // Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+    // "word" reveals word by word. 
+    var revealNextClozeMode = "cloze" 
+
+    // What cloze is hidden with
+    var clozeHider = (elem) => "👑"
+    /* 
+    You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
+
+    // Fixed length:
+    var clozeHider = (elem) => "███"
+    // Replace each character with "█":
+    var clozeHider = (elem) => "█".repeat(elem.textContent.length)
+    // Show whitespaces:
+    var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
+    // Color-filled box (doesn't hide images):
+    var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+    */
+
 </script>
 
 
@@ -311,7 +334,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Cloze-AnKingDerm/Back Template.html
+++ b/Note Types/Cloze-AnKingDerm/Back Template.html
@@ -104,6 +104,27 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -212,7 +233,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                       this.toggle()
@@ -348,8 +369,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -411,7 +432,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -458,7 +479,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         } 
 
         var isShortcut = shortcutMatcher(toggleTagsShortcut)
-        document.addEventListener('keyup', function (e) {
+        ankingAddEventListener(document, 'keyup', function (e) {
             if (isShortcut(e)) {
                 showtags();
             }
@@ -621,14 +642,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
       var pcc = document.getElementById("popup-container");
       var prevSel = "";
-      document.addEventListener('click', function() {
+      ankingAddEventListener(document, 'click', function() {
           var currentSelection = getSelectionText();
           if (currentSelection !==""){prevSel = currentSelection;}
           if (currentSelection && !mustClickW ){
     getSummaryFor(currentSelection);
            }else{closePopup();}
       });
-      document.addEventListener('keyup', function(e) {
+      ankingAddEventListener(document, 'keyup', function(e) {
           if(e.key =="w"){
           if(pcc.style.display ==="block"){closePopup();}else{getSummaryFor(prevSel);}
           }

--- a/Note Types/Cloze-AnKingDerm/Front Template.html
+++ b/Note Types/Cloze-AnKingDerm/Front Template.html
@@ -59,6 +59,54 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- Shortcut Matcher Function -->
+<script>
+    var specialCharCodes = {
+      "-": "minus",
+      "=": "equal",
+      "[": "bracketleft",
+      "]": "bracketright",
+      ";": "semicolon",
+      "'": "quote",
+      "`": "backquote",
+      "\\": "backslash",
+      ",": "comma",
+      ".": "period",
+      "/": "slash",
+    };
+    // Returns function that match keyboard event to see if it matches given shortcut.
+    function shortcutMatcher(shortcut) {
+      let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+      let mainKey = shortcutKeys[shortcutKeys.length - 1]
+      if (mainKey.length === 1) {
+        if (/\d/.test(mainKey)) {
+          mainKey = "digit" + mainKey
+        } else if (/[a-zA-Z]/.test(mainKey)) {
+          mainKey = "key" + mainKey
+        } else {
+          let code = specialCharCodes[mainKey];
+          if (code) {
+            mainKey = code
+          }
+        }
+      }
+      let ctrl = shortcutKeys.includes("ctrl")
+      let shift = shortcutKeys.includes("shift")
+      let alt = shortcutKeys.includes("alt")
+  
+      let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+        if (mainKey !== event.code.toLowerCase()) return false
+        if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+        if (shift !== event.shiftKey) return false
+        if (alt !== event.altKey) return false
+        return true
+      }.bind(window, ctrl, shift, alt, mainKey)
+      
+      return matchShortcut
+    }
+  </script>
+  
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>
@@ -92,8 +140,9 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKingDerm/Front Template.html
+++ b/Note Types/Cloze-AnKingDerm/Front Template.html
@@ -90,7 +90,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKingDerm/Front Template.html
+++ b/Note Types/Cloze-AnKingDerm/Front Template.html
@@ -17,6 +17,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Cloze-AnKingDerm/Front Template.html
+++ b/Note Types/Cloze-AnKingDerm/Front Template.html
@@ -59,6 +59,27 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
+
 <!-- Shortcut Matcher Function -->
 <script>
     var specialCharCodes = {
@@ -141,7 +162,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -22,9 +22,6 @@
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C"; // c
-
     // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
     var revealClozeShortcut = "N" // Shortcut to reveal next cloze
     var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -212,7 +212,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -263,7 +263,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -229,6 +229,165 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
+<script>
+  (function() {
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
+    } catch (exception) {
+      console.log(exception)
+    }
+
+    const hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    const revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
+    }
+
+    const revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
+      }
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    const hideloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    const attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
+</script>
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -70,6 +70,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <hr>
 
 <!-- BUTTON FIELDS -->
+
+<!-- ClOZE ONE BY ONE BUTTONS -->
+{{#One by one}}
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
+<br />
+{{/One by one}}
+
 {{#Lecture Notes}}<hint-button field-name="Lecture Notes" short="ln" hint-id="notes"></hint-button>
 <div id="dummy-ln" style="display: none;">{{edit:Lecture Notes}}</div>{{/Lecture Notes}}
 

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -25,6 +25,29 @@
     // ##############  TAG SHORTCUT  ##############
     var ToggleTagsShortcut = "C"; // c
 
+    // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
+    var revealClozeShortcut = "N" // Shortcut to reveal next cloze
+    var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
+
+    // Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+    // "word" reveals word by word. 
+    var revealNextClozeMode = "cloze" 
+
+    // What cloze is hidden with
+    var clozeHider = (elem) => "👑"
+    /* 
+    You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
+
+    // Fixed length:
+    var clozeHider = (elem) => "███"
+    // Replace each character with "█":
+    var clozeHider = (elem) => "█".repeat(elem.textContent.length)
+    // Show whitespaces:
+    var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
+    // Color-filled box (doesn't hide images):
+    var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+    */
+
 </script>
 
 
@@ -304,7 +327,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -23,7 +23,7 @@
     var tagID = "XXXYYYZZZ"
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C"; // c
+    var toggleTagsShortcut = "C"; // c
 
     // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
     var revealClozeShortcut = "N" // Shortcut to reveal next cloze
@@ -453,7 +453,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
         if (isShortcut(e)) {
             showtags();

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -97,6 +97,27 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -205,7 +226,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                       this.toggle()
@@ -341,8 +362,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -404,7 +425,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -451,7 +472,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
     
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }
@@ -613,14 +634,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
     var pcc = document.getElementById("popup-container");
     var prevSel = "";
-    document.addEventListener('click', function () {
+    ankingAddEventListener(document, 'click', function () {
         var currentSelection = getSelectionText();
         if (currentSelection !== "") { prevSel = currentSelection; }
         if (currentSelection && !mustClickW) {
             getSummaryFor(currentSelection);
         } else { closePopup(); }
     });
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (e.key == "w") {
             hhh
             if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }

--- a/Note Types/Cloze-AnKingMCAT/Back Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Back Template.html
@@ -1,15 +1,13 @@
 <script>
     // ##############  HINT REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Lecture Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
-        "Pixorize" : '51', // alt + 3
-        "Additional Resources" : '52', // alt + 4
+        "Lecture Notes" : "Alt + 1",
+        "Missed Questions" : "Alt + 2",
+        "Pixorize" : "Alt + 3",
+        "Additional Resources" : "Alt + 4",
     }
-    var ToggleAllButtons = '222' // '
+    var ToggleAllButtonsShortcut = '222' // '
 
     // ##############  SHOW HINTS AUTOMATICALLY  ##############
     var ButtonAutoReveal = {
@@ -25,8 +23,7 @@
     var tagID = "XXXYYYZZZ"
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C"; // c
 
 </script>
 
@@ -70,6 +67,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 
 <!-- TOGGLE BUTTONS -->
@@ -130,10 +175,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                      this.toggle()
+                    }
                     return false
                 })
             }
@@ -214,12 +262,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
+    
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });
-
 
 </script>
 {{/Tags}}

--- a/Note Types/Cloze-AnKingMCAT/Front Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Front Template.html
@@ -95,7 +95,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKingMCAT/Front Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Front Template.html
@@ -57,6 +57,26 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -147,7 +167,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
     }
 
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-AnKingMCAT/Front Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Front Template.html
@@ -58,6 +58,54 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
+
 <script>
     //DONT FADE BETWEEN CARDS
 	qFade=0; if (typeof anki !== 'undefined') anki.qFade=qFade;
@@ -97,8 +145,10 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKingMCAT/Front Template.html
+++ b/Note Types/Cloze-AnKingMCAT/Front Template.html
@@ -16,6 +16,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C"; // c
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -82,6 +82,12 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <hr>
 
+<!-- ClOZE ONE BY ONE BUTTONS -->
+{{#One by one}}
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
+<br />
+{{/One by one}}
 
 <!-- OME AUTO OPEN FIELD -->
 <div class="banner-ome">{{#OME}}{{OME}}{{/OME}}</div>

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -246,7 +246,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -297,7 +297,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -37,6 +37,29 @@
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 
+    // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
+    var revealClozeShortcut = "N" // Shortcut to reveal next cloze
+    var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
+
+    // Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+    // "word" reveals word by word. 
+    var revealNextClozeMode = "cloze" 
+
+    // What cloze is hidden with
+    var clozeHider = (elem) => "👑"
+    /* 
+    You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
+
+    // Fixed length:
+    var clozeHider = (elem) => "███"
+    // Replace each character with "█":
+    var clozeHider = (elem) => "█".repeat(elem.textContent.length)
+    // Show whitespaces:
+    var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
+    // Color-filled box (doesn't hide images):
+    var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+    */
+
 </script>
 
 
@@ -341,7 +364,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -266,6 +266,165 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
+<script>
+  (function() {
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
+    } catch (exception) {
+      console.log(exception)
+    }
+
+    const hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    const revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
+    }
+
+    const revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
+      }
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    const hideloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    const attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
+</script>
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -32,7 +32,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -442,7 +442,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -487,8 +487,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -132,6 +132,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -240,7 +260,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                       this.toggle()
@@ -376,8 +396,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -485,7 +505,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
+          console.log("showTags")
             showtags();
         }
     });
@@ -646,14 +668,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
     var pcc = document.getElementById("popup-container");
     var prevSel = "";
-    document.addEventListener('click', function () {
+    ankingAddEventListener(document, 'click', function () {
         var currentSelection = getSelectionText();
         if (currentSelection !== "") { prevSel = currentSelection; }
         if (currentSelection && !mustClickW) {
             getSummaryFor(currentSelection);
         } else { closePopup(); }
     });
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (e.key == "w") {
             if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
         }

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -31,9 +31,6 @@
 
     var ScrollToButton = true;
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C";
-
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Cloze-AnKingMaster-v3/Back Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Back Template.html
@@ -1,21 +1,19 @@
 <script>
     // ##############  HINT REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Lecture Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
-        "Pathoma" : '51', // alt + 3
-        "Boards and Beyond" : '52', // alt + 4
-        "First Aid" : '53', // alt + 5
-        "Sketchy" : '54', // alt + 6
-        "Pixorize" : '55', // alt + 7
-        "Physeo" : '56', // alt + 8
-        "OME" : '112', // alt + f1
-        "Additional Resources" : '57', // alt + 9
+        "Lecture Notes" : "Alt + 1",
+        "Missed Questions" : "Alt + 2",
+        "Pathoma" : "Alt + 3",
+        "Boards and Beyond" : "Alt + 4",
+        "First Aid" : "Alt + 5",
+        "Sketchy" : "Alt + 6",
+        "Pixorize" : "Alt + 7",
+        "Physeo" : "Alt + 8",
+        "OME" : "Alt + F1",
+        "Additional Resources" : 'Alt + 9',
     }
-    var ToggleAllButtons = '222' // '
+    var ToggleAllButtonsShortcut = "'"
 
     // ##############  SHOW HINTS AUTOMATICALLY  ##############
     var ButtonAutoReveal = {
@@ -34,8 +32,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -109,6 +106,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
+
 <!-- TOGGLE BUTTONS -->
 <script>
     function defineHintButton() {
@@ -167,10 +212,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                      this.toggle()
+                    }
                     return false
                 })
             }
@@ -251,12 +299,12 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });
-
 
 </script>
 {{/Tags}}

--- a/Note Types/Cloze-AnKingMaster-v3/Front Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Front Template.html
@@ -16,6 +16,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var minutes = 0
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
+    
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"

--- a/Note Types/Cloze-AnKingMaster-v3/Front Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Front Template.html
@@ -27,6 +27,27 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -147,7 +168,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-AnKingMaster-v3/Front Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Front Template.html
@@ -95,8 +95,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
-    document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Cloze-AnKingMaster-v3/Front Template.html
+++ b/Note Types/Cloze-AnKingMaster-v3/Front Template.html
@@ -27,6 +27,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
+
 <!-- COUNTDOWN TIMER -->
 <div class="timer" id="s2"></div>
 <script>
@@ -98,7 +146,9 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
-        if (e.keyCode == toggleTagsShortcut) {
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
+    document.addEventListener('keyup', function (e) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -147,15 +147,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <script>
   (function() {
+    var clozeOneByOneEnabled = true 
     /*
-    var clozeOneByOneEnabled = true;
     try {
-        clozeOneByOneEnabled = `{ {One by one} }` === ""
+        clozeOneByOneEnabled = `{ {One by one} }`.trim() !== ""
     } catch (exception) {
       console.log(exception)
     }
     */
-    var clozeOneByOneEnabled = true 
 
     const hideCloze = function(cloze) {
       if (!clozeOneByOneEnabled) {

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -364,7 +364,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -415,7 +415,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -85,16 +85,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <div id="extra">{{edit:Extra}}</div>
 {{/Extra}}<br>
 
-
-
-<!-- CLOZE ONE BY ONE SCRIPT -->
-<style>
-.cloze[data-content]:hover {
-  cursor: pointer;
-}
-</style>
-
-
 <!-- Shortcut Matcher Function -->
 <script>
 var specialCharCodes = {
@@ -142,7 +132,14 @@ function shortcutMatcher(shortcut) {
 }
 </script>
 
-<!-- Cloze One by One -->
+
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
 <script>
 (function() {
   /*
@@ -154,8 +151,6 @@ function shortcutMatcher(shortcut) {
   }
   */
   var clozeOneByOneEnabled = true 
-
-  // Declared to window scope to avoid redeclaring for every card.
 
   let hideCloze = function(cloze) {
     if (!clozeOneByOneEnabled) {

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -25,14 +25,12 @@ var clozeHider = (elem) => `<span style="background-color: red; color: transpare
 */
 
 // ~~~~~~~~~~~~~  HINT REVEAL SHORTCUTS  ~~~~~~~~~~~~~
-// Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-// The shortcuts are  Alt  +  the number/letter below
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
 var ButtonShortcuts = {
-    "Personal Notes" : '49', // alt + 1
-    "Missed Questions" : '50', // alt + 2
+    "Personal Notes" : "Alt + 1",
+    "Missed Questions" : "Alt + 2",
 }
-var ToggleAllButtons = '222' // '
+var ToggleAllButtons = "'"
 
 // ~~~~~~~~~~~~~  SHOW HINTS AUTOMATICALLY  ~~~~~~~~~~~~~
 var ButtonAutoReveal = {
@@ -43,8 +41,7 @@ var ButtonAutoReveal = {
 var ScrollToButton = true;
 
 // ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
-// Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-var ToggleTags = "67"; // c
+var ToggleTagsShortcut = "C";
 
 //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
 var tagID = "XXXYYYZZZ"
@@ -365,10 +362,13 @@ function shortcutMatcher(shortcut) {
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtons)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                      this.toggle()
+                    }
                     return false
                 })
             }
@@ -449,8 +449,9 @@ function shortcutMatcher(shortcut) {
                 "none";
         }
     }
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -3,9 +3,10 @@
 
 <script>
 var revealClozeShortcut = "N" // Shortcut to reveal next cloze
-var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next cloze word
+var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
 
-// Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word". 
+// Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+// "word" reveals word by word. 
 var revealNextMode = "cloze" 
 
 // What cloze is hidden with
@@ -13,12 +14,12 @@ var clozeHidden = (elem) => "👑"
 /* 
 You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
 
-// Fixed length  (default):
+// Fixed length:
 var clozeHidden = (elem) => "███"
-// Replace all characters with "█":
+// Replace each character with "█":
 var clozeHidden = (elem) => "█".repeat(elem.textContent.length)
 // Show whitespaces:
-var clozeHidden = (elem) => "[" + elem.textContent.split(" ").map((t) => "_".repeat(t.length)).join(" ") + "]"
+var clozeHidden = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
 // Color-filled box (doesn't hide images):
 var clozeHidden = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
 */

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -98,47 +98,45 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </style>
 
 <script>
-if (!window.shortcutMatcher) {
-  // Returns function that match keyboard event to see if it matches given shortcut.
-  window.shortcutMatcher = function (shortcut) {
-    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
-    let mainKey = shortcutKeys[shortcutKeys.length - 1]
-    if (mainKey.length === 1) {
-        let prepend = /\d/.test(mainKey) ? "digit" : "key"
-        mainKey = prepend + mainKey
-    }
-    let ctrl = shortcutKeys.includes("ctrl")
-    let shift = shortcutKeys.includes("shift")
-    let alt = shortcutKeys.includes("alt")
-
-    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
-      if (mainKey !== event.code.toLowerCase()) return false
-      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
-      if (shift !== event.shiftKey) return false
-      if (alt !== event.altKey) return false
-      return true
-    }.bind(window, ctrl, shift, alt, mainKey)
-    
-    return matchShortcut
+// Returns function that match keyboard event to see if it matches given shortcut.
+function shortcutMatcher(shortcut) {
+  let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+  let mainKey = shortcutKeys[shortcutKeys.length - 1]
+  if (mainKey.length === 1) {
+      let prepend = /\d/.test(mainKey) ? "digit" : "key"
+      mainKey = prepend + mainKey
   }
+  let ctrl = shortcutKeys.includes("ctrl")
+  let shift = shortcutKeys.includes("shift")
+  let alt = shortcutKeys.includes("alt")
+
+  let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+    if (mainKey !== event.code.toLowerCase()) return false
+    if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+    if (shift !== event.shiftKey) return false
+    if (alt !== event.altKey) return false
+    return true
+  }.bind(window, ctrl, shift, alt, mainKey)
+  
+  return matchShortcut
 }
 </script>
 
 <script>
-/*
-var clozeOneByOneEnabled = true;
-try {
-    clozeOneByOneEnabled = `{ {One by one} }` === ""
-} catch (exception) {
-  console.log(exception)
-}
-*/
-var clozeOneByOneEnabled = true 
+(function() {
+  /*
+  var clozeOneByOneEnabled = true;
+  try {
+      clozeOneByOneEnabled = `{ {One by one} }` === ""
+  } catch (exception) {
+    console.log(exception)
+  }
+  */
+  var clozeOneByOneEnabled = true 
 
-// Declared to window scope to avoid redeclaring for every card.
-if (!window.revealCloze) {
+  // Declared to window scope to avoid redeclaring for every card.
 
-  window.hideCloze = function(cloze) {
+  let hideCloze = function(cloze) {
     if (!clozeOneByOneEnabled) {
       return
     }
@@ -150,7 +148,7 @@ if (!window.revealCloze) {
       }
   }
   
-  window.revealCloze = function(elem) {
+  let revealCloze = function(elem) {
     // Checking for dataset.content is undefined may not be needed anymore?
     if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
       return
@@ -159,7 +157,7 @@ if (!window.revealCloze) {
     delete elem.dataset.content
   }
 
-  window.revealClozeWord = function(elem) {
+  let revealClozeWord = function(elem) {
     if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
       return
     }
@@ -197,7 +195,7 @@ if (!window.revealCloze) {
     }
   }
 
-  window.hideAllCloze = function(initial) {
+  let hideAllCloze = function(initial) {
     let clozes = document.getElementsByClassName("cloze")
     for (let i = 0; i < clozes.length; i++) {
       let cloze = clozes[i]
@@ -220,11 +218,11 @@ if (!window.revealCloze) {
           revealCloze(elems[i])
       }
     } else {
-      window.hideAllCloze(initial=false)
+      hideAllCloze(initial=false)
     }
   }
 
-  window.revealClozeClicked = function(ev) {
+  let revealClozeClicked = function(ev) {
     let elem = ev.currentTarget
     if (elem.dataset.content === undefined) {
       return
@@ -238,36 +236,47 @@ if (!window.revealCloze) {
     ev.preventDefault()
   }
 
-  let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
-  let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
-  document.addEventListener("keydown",  function(ev) {
-    if(showAllShortcut(ev)) {
-      let elem = document.querySelector(".cloze[data-content]")
-      if (elem) {
-        revealCloze(elem)
-        ev.stopPropagation()
-        ev.preventDefault()
-        return
-      }
+  // previously attached listener should be removed.
+  //
+  // In case the keydown listener changes between versions across notetypes
+  // and if shortcut is different across notetypes, attached every time.
+  let attachKeydownListener = function() {
+    if(window.revealClozeKeydownListener) {
+      document.removeEventListener("keydown", window.revealClozeKeydownListener)
     }
-    if (showWordShortcut(ev)) {
-      let elem = document.querySelector(".cloze[data-content]")
-      if (elem) {
-        revealClozeWord(elem)
-        ev.stopPropagation()
-        ev.preventDefault()
-        return
-      }
-    }
-  });
-}
-</script>
 
-<script>
-(function(){
+    let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+    let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+
+    window.revealClozeKeydownListener = function(ev) {
+      if(showAllShortcut(ev)) {
+        let elem = document.querySelector(".cloze[data-content]")
+        if (elem) {
+          revealCloze(elem)
+          ev.stopPropagation()
+          ev.preventDefault()
+          return
+        }
+      }
+      if (showWordShortcut(ev)) {
+        let elem = document.querySelector(".cloze[data-content]")
+        if (elem) {
+          revealClozeWord(elem)
+          ev.stopPropagation()
+          ev.preventDefault()
+          return
+        }
+      }
+    }
+    document.addEventListener("keydown", window.revealClozeKeydownListener);
+  }
+  
   // autoflip hides card in front template
   document.getElementById("qa").style.removeProperty("display")
-  window.hideAllCloze(initial=true)
+  hideAllCloze(initial=true)
+
+  attachKeydownListener()
 })()
 
 </script>

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -88,6 +88,27 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -222,8 +243,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -285,7 +306,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -357,7 +378,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                       this.toggle()
@@ -443,7 +464,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }
@@ -606,14 +627,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   }
   var pcc = document.getElementById("popup-container");
   var prevSel = "";
-  document.addEventListener('click', function () {
+  ankingAddEventListener(document, 'click', function () {
       var currentSelection = getSelectionText();
       if (currentSelection !== "") { prevSel = currentSelection; }
       if (currentSelection && !mustClickW) {
           getSummaryFor(currentSelection);
       } else { closePopup(); }
   });
-  document.addEventListener('keyup', function (e) {
+  ankingAddEventListener(document, 'keyup', function (e) {
       if (e.key == "w") {
           if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
       }

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -200,6 +200,9 @@ if (!window.revealCloze) {
     let clozes = document.getElementsByClassName("cloze")
     for (let i = 0; i < clozes.length; i++) {
       let cloze = clozes[i]
+      if (cloze.offsetWidth === 0) {
+        continue
+      }
       hideCloze(cloze)
       if (initial === true) {
         cloze.addEventListener("touchend", revealClozeClicked)
@@ -258,14 +261,13 @@ if (!window.revealCloze) {
   });
 
 }
+</script>
 
+<script>
 (function(){
-  try{
-    window.hideAll(initial=true)
-  } finally {
-    // autoflip hides card in front template
-    document.getElementById("qa").style.removeProperty("display")
-  }
+  // autoflip hides card in front template
+  document.getElementById("qa").style.removeProperty("display")
+  window.hideAll(initial=true)
 })()
 
 </script>

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -30,7 +30,7 @@ var ButtonShortcuts = {
     "Personal Notes" : "Alt + 1",
     "Missed Questions" : "Alt + 2",
 }
-var ToggleAllButtons = "'"
+var ToggleAllButtonsShortcut = "'"
 
 // ~~~~~~~~~~~~~  SHOW HINTS AUTOMATICALLY  ~~~~~~~~~~~~~
 var ButtonAutoReveal = {
@@ -87,49 +87,49 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- Shortcut Matcher Function -->
 <script>
-var specialCharCodes = {
-  "-": "minus",
-  "=": "equal",
-  "[": "bracketleft",
-  "]": "bracketright",
-  ";": "semicolon",
-  "'": "quote",
-  "`": "backquote",
-  "\\": "backslash",
-  ",": "comma",
-  ".": "period",
-  "/": "slash",
-};
-// Returns function that match keyboard event to see if it matches given shortcut.
-function shortcutMatcher(shortcut) {
-  let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
-  let mainKey = shortcutKeys[shortcutKeys.length - 1]
-  if (mainKey.length === 1) {
-    if (/\d/.test(mainKey)) {
-      mainKey = 'digit' + mainKey
-    } else if (/[a-zA-Z]/.test(mainKey)) {
-      mainKey = 'key' + mainKey
-    } else {
-      let code = specialCharCodes[mainKey];
-      if (code) {
-        mainKey = code
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
       }
     }
-  }
-  let ctrl = shortcutKeys.includes("ctrl")
-  let shift = shortcutKeys.includes("shift")
-  let alt = shortcutKeys.includes("alt")
-
-  let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
-    if (mainKey !== event.code.toLowerCase()) return false
-    if (ctrl !== (event.ctrlKey || event.metaKey)) return false
-    if (shift !== event.shiftKey) return false
-    if (alt !== event.altKey) return false
-    return true
-  }.bind(window, ctrl, shift, alt, mainKey)
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
   
-  return matchShortcut
-}
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
 </script>
 
 
@@ -141,159 +141,159 @@ function shortcutMatcher(shortcut) {
 </style>
 
 <script>
-(function() {
-  /*
-  var clozeOneByOneEnabled = true;
-  try {
-      clozeOneByOneEnabled = `{ {One by one} }` === ""
-  } catch (exception) {
-    console.log(exception)
-  }
-  */
-  var clozeOneByOneEnabled = true 
+  (function() {
+    /*
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{ {One by one} }` === ""
+    } catch (exception) {
+      console.log(exception)
+    }
+    */
+    var clozeOneByOneEnabled = true 
 
-  let hideCloze = function(cloze) {
-    if (!clozeOneByOneEnabled) {
-      return
-    }
-    cloze.dataset.content = cloze.innerHTML
-      if(window.clozeHints && window.clozeHints[i]) {
-          cloze.innerHTML = window.clozeHints[i]
-      } else {
-          cloze.innerHTML = clozeHider(cloze)
-      }
-  }
-  
-  let revealCloze = function(elem) {
-    // Checking for dataset.content is undefined may not be needed anymore?
-    if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
-      return
-    }
-    elem.innerHTML = elem.dataset.content
-    delete elem.dataset.content
-  }
-
-  let revealClozeWord = function(elem) {
-    if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
-      return
-    }
-    if (elem.dataset.hidden !== undefined) {
-      let words = elem.dataset.hidden.split(" ");
-      if (words.length == 1) {
-        revealCloze(elem)
-        delete elem.dataset.hidden
-        delete elem.dataset.revealed
-      } else {
-        elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-        elem.dataset.hidden = words.slice(1).join(" ");
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.hidden;
-        elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-      }
-    } else {
-      let temp = document.createElement("div");
-      temp.innerHTML = elem.dataset.content;
-      elem.dataset.hidden = temp.textContent;
-      elem.dataset.revealed = "";
-      revealClozeWord(elem)
-    }
-  }
-
-  window.revealNextCloze = function() {
-    let nextHidden = document.querySelector(".cloze[data-content]")
-    if(!nextHidden) {
+    let hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
         return
-    } 
-    if (revealNextClozeMode === "word") {
-        revealClozeWord(nextHidden)
-    } else {
-        revealCloze(nextHidden)
-    }
-  }
-
-  let hideAllCloze = function(initial) {
-    let clozes = document.getElementsByClassName("cloze")
-    for (let i = 0; i < clozes.length; i++) {
-      let cloze = clozes[i]
-      if (cloze.offsetWidth === 0) {
-        continue
       }
-      hideCloze(cloze)
-      if (initial === true) {
-        cloze.addEventListener("touchend", revealClozeClicked)
-        cloze.addEventListener("click", revealClozeClicked)
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    let revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
       }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
     }
-  }
 
-  window.toggleAllCloze = function() {
-    let elems = document.querySelectorAll(".cloze[data-content]")
-    let button = document.getElementById("button-toggle-all")
-    if(elems.length > 0) {
-      for (let i = 0; i < elems.length; i++) {
-          revealCloze(elems[i])
+    let revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
       }
-    } else {
-      hideAllCloze(initial=false)
-    }
-  }
-
-  let revealClozeClicked = function(ev) {
-    let elem = ev.currentTarget
-    if (elem.dataset.content === undefined) {
-      return
-    }
-    if (!ev.altKey && (revealNextClozeMode !== "word")) {
-      revealCloze(elem)
-    } else {
-      revealClozeWord(elem)
-    }
-    ev.stopPropagation()
-    ev.preventDefault()
-  }
-
-  // previously attached listener should be removed.
-  //
-  // In case the keydown listener changes between versions across notetypes
-  // and if shortcut is different across notetypes, attached every time.
-  let attachKeydownListener = function() {
-    if(window.revealClozeKeydownListener) {
-      document.removeEventListener("keydown", window.revealClozeKeydownListener)
-    }
-
-    let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
-    let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
-
-
-    window.revealClozeKeydownListener = function(ev) {
-      if(showAllShortcut(ev)) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
           revealCloze(elem)
-          ev.stopPropagation()
-          ev.preventDefault()
-          return
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
         }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
       }
-      if (showWordShortcut(ev)) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          revealClozeWord(elem)
-          ev.stopPropagation()
-          ev.preventDefault()
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
           return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    let hideAllCloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
         }
       }
     }
-    document.addEventListener("keydown", window.revealClozeKeydownListener);
-  }
-  
-  // autoflip hides card in front template
-  document.getElementById("qa").style.removeProperty("display")
-  hideAllCloze(initial=true)
 
-  attachKeydownListener()
-})()
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    let revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    let attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
 </script>
 
 
@@ -360,7 +360,7 @@ function shortcutMatcher(shortcut) {
                 }
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
-                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtons)
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -43,7 +43,7 @@ var ButtonAutoReveal = {
 var ScrollToButton = true;
 
 // ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
-var ToggleTagsShortcut = "C";
+var toggleTagsShortcut = "C";
 
 //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
 var tagID = "XXXYYYZZZ"
@@ -445,7 +445,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
         if (isShortcut(e)) {
             showtags();

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -98,13 +98,34 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </style>
 
 <script>
+var specialCharCodes = {
+  "-": "minus",
+  "=": "equal",
+  "[": "bracketleft",
+  "]": "bracketright",
+  ";": "semicolon",
+  "'": "quote",
+  "`": "backquote",
+  "\\": "backslash",
+  ",": "comma",
+  ".": "period",
+  "/": "slash",
+};
 // Returns function that match keyboard event to see if it matches given shortcut.
 function shortcutMatcher(shortcut) {
   let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
   let mainKey = shortcutKeys[shortcutKeys.length - 1]
   if (mainKey.length === 1) {
-      let prepend = /\d/.test(mainKey) ? "digit" : "key"
-      mainKey = prepend + mainKey
+    if (/\d/.test(mainKey)) {
+      mainKey = 'digit' + mainKey
+    } else if (/[a-zA-Z]/.test(mainKey)) {
+      mainKey = 'key' + mainKey
+    } else {
+      let code = specialCharCodes[mainKey];
+      if (code) {
+        mainKey = code
+      }
+    }
   }
   let ctrl = shortcutKeys.includes("ctrl")
   let shift = shortcutKeys.includes("shift")

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -125,8 +125,21 @@ if (!window.shortcutMatcher) {
 </script>
 
 <script>
+/*
+var clozeOneByOneEnabled = true;
+try {
+    clozeOneByOneEnabled = `{ {One by one} }` === ""
+} catch (exception) {
+  console.log(exception)
+}
+*/
+var clozeOneByOneEnabled = true 
+
 if (!window.revealCloze) {
   window.hideCloze = function(cloze) {
+    if (!clozeOneByOneEnabled) {
+      return
+    }
     cloze.dataset.content = cloze.innerHTML
       if(window.clozeHints && window.clozeHints[i]) {
           cloze.innerHTML = window.clozeHints[i]
@@ -136,15 +149,16 @@ if (!window.revealCloze) {
   }
   
   window.revealCloze = function(elem) {
-    // This if may not be needed anymore. Redundancy.
-    if (elem.dataset.content !== undefined) { 
+    // Checking for dataset.content is undefined may not be needed anymore?
+    if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+      return
+    }
       elem.innerHTML = elem.dataset.content
       delete elem.dataset.content
-    }
   }
 
   window.revealClozeWord = function(elem) {
-    if (elem.dataset.content === undefined) {
+    if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
       return
     }
     if (elem.dataset.hidden !== undefined) {

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -238,8 +238,9 @@ if (!window.revealCloze) {
     ev.preventDefault()
   }
 
+  let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+  let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
   document.addEventListener("keydown",  function(ev) {
-    let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
     if(showAllShortcut(ev)) {
       let elem = document.querySelector(".cloze[data-content]")
       if (elem) {
@@ -249,7 +250,6 @@ if (!window.revealCloze) {
         return
       }
     }
-    let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
     if (showWordShortcut(ev)) {
       let elem = document.querySelector(".cloze[data-content]")
       if (elem) {
@@ -260,7 +260,6 @@ if (!window.revealCloze) {
       }
     }
   });
-
 }
 </script>
 

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -215,7 +215,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -7,21 +7,21 @@ var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word
 
 // Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
 // "word" reveals word by word. 
-var revealNextMode = "cloze" 
+var revealNextClozeMode = "cloze" 
 
 // What cloze is hidden with
-var clozeHidden = (elem) => "👑"
+var clozeHider = (elem) => "👑"
 /* 
 You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
 
 // Fixed length:
-var clozeHidden = (elem) => "███"
+var clozeHider = (elem) => "███"
 // Replace each character with "█":
-var clozeHidden = (elem) => "█".repeat(elem.textContent.length)
+var clozeHider = (elem) => "█".repeat(elem.textContent.length)
 // Show whitespaces:
-var clozeHidden = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
+var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
 // Color-filled box (doesn't hide images):
-var clozeHidden = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
 */
 
 // ~~~~~~~~~~~~~  HINT REVEAL SHORTCUTS  ~~~~~~~~~~~~~
@@ -72,8 +72,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 <!-- BUTTON FIELDS -->
-<button id="button-reveal-next" class="button-general" onclick="revealNext()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleRevealAll()">Toggle All</button>
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
 <br>
 <div class="btn-spacer" hidden></div>
 <hint-button field-name="Personal Notes" short="ln" hint-id="notes"></hint-button>
@@ -135,7 +135,9 @@ try {
 */
 var clozeOneByOneEnabled = true 
 
+// Declared to window scope to avoid redeclaring for every card.
 if (!window.revealCloze) {
+
   window.hideCloze = function(cloze) {
     if (!clozeOneByOneEnabled) {
       return
@@ -144,7 +146,7 @@ if (!window.revealCloze) {
       if(window.clozeHints && window.clozeHints[i]) {
           cloze.innerHTML = window.clozeHints[i]
       } else {
-          cloze.innerHTML = clozeHidden(cloze)
+          cloze.innerHTML = clozeHider(cloze)
       }
   }
   
@@ -172,7 +174,7 @@ if (!window.revealCloze) {
         elem.dataset.hidden = words.slice(1).join(" ");
         let temp = document.createElement("div");
         temp.innerHTML = elem.dataset.hidden;
-        elem.innerHTML = elem.dataset.revealed + " " + clozeHidden(temp);
+        elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
       }
     } else {
       let temp = document.createElement("div");
@@ -183,20 +185,19 @@ if (!window.revealCloze) {
     }
   }
 
-  window.revealNext = function() {
+  window.revealNextCloze = function() {
     let nextHidden = document.querySelector(".cloze[data-content]")
     if(!nextHidden) {
         return
     } 
-    if (revealNextMode === "word") {
+    if (revealNextClozeMode === "word") {
         revealClozeWord(nextHidden)
     } else {
         revealCloze(nextHidden)
     }
-    return
   }
 
-  window.hideAll = function(initial) {
+  window.hideAllCloze = function(initial) {
     let clozes = document.getElementsByClassName("cloze")
     for (let i = 0; i < clozes.length; i++) {
       let cloze = clozes[i]
@@ -211,7 +212,7 @@ if (!window.revealCloze) {
     }
   }
 
-  window.toggleRevealAll = function() {
+  window.toggleAllCloze = function() {
     let elems = document.querySelectorAll(".cloze[data-content]")
     let button = document.getElementById("button-toggle-all")
     if(elems.length > 0) {
@@ -219,7 +220,7 @@ if (!window.revealCloze) {
           revealCloze(elems[i])
       }
     } else {
-      window.hideAll(initial=false)
+      window.hideAllCloze(initial=false)
     }
   }
 
@@ -228,7 +229,7 @@ if (!window.revealCloze) {
     if (elem.dataset.content === undefined) {
       return
     }
-    if (!ev.altKey && (revealNextMode !== "word")) {
+    if (!ev.altKey && (revealNextClozeMode !== "word")) {
       revealCloze(elem)
     } else {
       revealClozeWord(elem)
@@ -267,7 +268,7 @@ if (!window.revealCloze) {
 (function(){
   // autoflip hides card in front template
   document.getElementById("qa").style.removeProperty("display")
-  window.hideAll(initial=true)
+  window.hideAllCloze(initial=true)
 })()
 
 </script>

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -2,6 +2,8 @@
 ################  USER CUSTOMIZATION START  ############## -->
 
 <script>
+
+// ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
 var revealClozeShortcut = "N" // Shortcut to reveal next cloze
 var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
 
@@ -85,6 +87,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <div id="extra">{{edit:Extra}}</div>
 {{/Extra}}<br>
 
+<!-- ANKING HYPERLINK IMAGE -->
+<a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -152,7 +157,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     */
     var clozeOneByOneEnabled = true 
 
-    let hideCloze = function(cloze) {
+    const hideCloze = function(cloze) {
       if (!clozeOneByOneEnabled) {
         return
       }
@@ -164,7 +169,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     
-    let revealCloze = function(elem) {
+    const revealCloze = function(elem) {
       // Checking for dataset.content is undefined may not be needed anymore?
       if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
         return
@@ -173,7 +178,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       delete elem.dataset.content
     }
 
-    let revealClozeWord = function(elem) {
+    const revealClozeWord = function(elem) {
       if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
         return
       }
@@ -211,7 +216,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    let hideAllCloze = function(initial) {
+    const hideloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]
@@ -238,7 +243,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    let revealClozeClicked = function(ev) {
+    const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
       if (elem.dataset.content === undefined) {
         return
@@ -256,14 +261,12 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     //
     // In case the keydown listener changes between versions across notetypes
     // and if shortcut is different across notetypes, attached every time.
-    let attachKeydownListener = function() {
+    const attachKeydownListener = function() {
       if(window.revealClozeKeydownListener) {
         document.removeEventListener("keydown", window.revealClozeKeydownListener)
       }
-
       let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
       let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
-
 
       window.revealClozeKeydownListener = function(ev) {
         if(showAllShortcut(ev)) {
@@ -295,10 +298,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     attachKeydownListener()
   })()
 </script>
-
-
-<!-- ANKING HYPERLINK IMAGE -->
-<a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
 
 <!-- TOGGLE BUTTONS -->

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -71,8 +71,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 <!-- BUTTON FIELDS -->
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+<!-- CLOZE ONE BY ONE-->
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
 <br>
 <div class="btn-spacer" hidden></div>
 <hint-button field-name="Personal Notes" short="ln" hint-id="notes"></hint-button>

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -42,9 +42,6 @@ var ButtonAutoReveal = {
 
 var ScrollToButton = true;
 
-// ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
-var toggleTagsShortcut = "C";
-
 //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
 var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -153,8 +153,8 @@ if (!window.revealCloze) {
     if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
       return
     }
-      elem.innerHTML = elem.dataset.content
-      delete elem.dataset.content
+    elem.innerHTML = elem.dataset.content
+    delete elem.dataset.content
   }
 
   window.revealClozeWord = function(elem) {
@@ -196,6 +196,18 @@ if (!window.revealCloze) {
     return
   }
 
+  window.hideAll = function(initial) {
+    let clozes = document.getElementsByClassName("cloze")
+    for (let i = 0; i < clozes.length; i++) {
+      let cloze = clozes[i]
+      hideCloze(cloze)
+      if (initial === true) {
+        cloze.addEventListener("touchend", revealClozeClicked)
+        cloze.addEventListener("click", revealClozeClicked)
+      }
+    }
+  }
+
   window.toggleRevealAll = function() {
     let elems = document.querySelectorAll(".cloze[data-content]")
     let button = document.getElementById("button-toggle-all")
@@ -204,10 +216,7 @@ if (!window.revealCloze) {
           revealCloze(elems[i])
       }
     } else {
-      let elems = document.querySelectorAll(".cloze")
-      for (let i = 0; i < elems.length; i++) {
-      hideCloze(elems[i])
-      }
+      window.hideAll(initial=false)
     }
   }
 
@@ -252,14 +261,7 @@ if (!window.revealCloze) {
 
 (function(){
   try{
-    let clozes = document.getElementsByClassName("cloze")
-    for (let i = 0; i < clozes.length; i++) {
-      let cloze = clozes[i]
-      hideCloze(cloze)
-      cloze.addEventListener("touchend", revealClozeClicked)
-      cloze.addEventListener("click", revealClozeClicked)
-
-    }
+    window.hideAll(initial=true)
   } finally {
     // autoflip hides card in front template
     document.getElementById("qa").style.removeProperty("display")

--- a/Note Types/Cloze-one by one/Back Template.html
+++ b/Note Types/Cloze-one by one/Back Template.html
@@ -94,6 +94,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 }
 </style>
 
+
+<!-- Shortcut Matcher Function -->
 <script>
 var specialCharCodes = {
   "-": "minus",
@@ -140,6 +142,7 @@ function shortcutMatcher(shortcut) {
 }
 </script>
 
+<!-- Cloze One by One -->
 <script>
 (function() {
   /*
@@ -296,7 +299,6 @@ function shortcutMatcher(shortcut) {
 
   attachKeydownListener()
 })()
-
 </script>
 
 

--- a/Note Types/Cloze-one by one/Front Template.html
+++ b/Note Types/Cloze-one by one/Front Template.html
@@ -106,6 +106,26 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 	qFade=0; if (typeof anki !== 'undefined') anki.qFade=qFade;
 </script>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -190,7 +210,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
     }
 
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Cloze-one by one/Front Template.html
+++ b/Note Types/Cloze-one by one/Front Template.html
@@ -107,6 +107,54 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 </script>
 
 
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>
@@ -140,8 +188,10 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Cloze-one by one/Front Template.html
+++ b/Note Types/Cloze-one by one/Front Template.html
@@ -26,8 +26,18 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 <script>
+/*
+var clozeOneByOneEnabled = true;
+try {
+    clozeOneByOneEnabled = `{ {One by one} }` === ""
+} catch (exception) {
+  console.log(exception)
+}
+*/
+var clozeOneByOneEnabled = true 
+
 // AUTO-FLIP if cloze has hint
-if(autoflip) {
+if(clozeOneByOneEnabled && autoflip) {
     // avoid flickering
     document.getElementById("qa").style.display = "none";
     window.clozeHints = [];

--- a/Note Types/Cloze-one by one/Front Template.html
+++ b/Note Types/Cloze-one by one/Front Template.html
@@ -138,7 +138,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Cloze-one by one/Front Template.html
+++ b/Note Types/Cloze-one by one/Front Template.html
@@ -18,6 +18,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -4,7 +4,7 @@
     var ToggleAllOcclusions = ",";
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     // ##############  BUTTON SETTINGS  ##############
     // All buttons will also open with "H" if using the Hint Hotkeys add-on 
@@ -139,7 +139,7 @@
         }
         if (!globalThis.ToggleTagsListening) {
             globalThis.ToggleTagsListening = true
-            var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+            var isShortcut = shortcutMatcher(toggleTagsShortcut)
             document.addEventListener('keydown', function (e) {
               if (e.repeat) return
                 if (isShortcut(e)) {

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,22 +1,20 @@
 <script>
     // ##############  OCCLUSION SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var RevealIncremental = "78"; // n
-    var ToggleAllOcclusions = "188"; // ,
+    var RevealIncremental = "N";
+    var ToggleAllOcclusions = ",";
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
     // ##############  BUTTON SETTINGS  ##############
-    // The button shortcuts are  Alt + the number/letter the keycode stands for
     // All buttons will also open with "H" if using the Hint Hotkeys add-on 
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
     var ButtonShortcuts = {
-        "Extra": '49', // alt + 1
-        "Personal Notes": '50', // alt + 2
-        "Missed Questions": '51', // alt + 3
+        "Extra": "Alt + 1",
+        "Personal Notes": "Alt + 2",
+        "Missed Questions": "Alt + 3",
     }
+
+    var ToggleAllButtonsShortcut = "'"
 
     // change values from false to true to have the fields revealed from the start
     var ButtonAutoReveal = {
@@ -25,7 +23,6 @@
         "Missed Questions": false,
     }
 
-    var ToggleAllButtons = '222' // '
     var ScrollToButton = true
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
@@ -57,6 +54,54 @@
 
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>  
 
 
 <div id="anki-am" data-name="Assets by ASSET MANAGER" data-version="2.1">
@@ -94,11 +139,11 @@
         }
         if (!globalThis.ToggleTagsListening) {
             globalThis.ToggleTagsListening = true
-            document.addEventListener('keydown', function (evt) {
-                if (evt.repeat) return
-                evt = evt || window.event
-                if (evt.keyCode == ToggleTags) {
-                    toggleTags();
+            var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+            document.addEventListener('keydown', function (e) {
+              if (e.repeat) return
+                if (isShortcut(e)) {
+                    showtags();
                 }
             });
         }
@@ -163,10 +208,13 @@
                         this.toggle()
                     }
 
+                    var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                    var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                     document.addEventListener("keydown", (evt) => {
                         if (evt.repeat) return
-                        if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                        if (evt.keyCode == ToggleAllButtons) this.toggle()
+                        if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                        this.toggle()
+                        }
                         return false
                     })
                 }

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -52,6 +52,26 @@
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -137,7 +157,7 @@
         if (!globalThis.ToggleTagsListening) {
             globalThis.ToggleTagsListening = true
             var isShortcut = shortcutMatcher(toggleTagsShortcut)
-            document.addEventListener('keydown', function (e) {
+            ankingAddEventListener(document, 'keydown', function (e) {
               if (e.repeat) return
                 if (isShortcut(e)) {
                     showtags();
@@ -207,7 +227,7 @@
 
                     var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                     var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                    document.addEventListener("keydown", (evt) => {
+                    ankingAddEventListener(document, "keydown", (evt) => {
                         if (evt.repeat) return
                         if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                         this.toggle()

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -213,7 +213,7 @@
                     }
 
                     // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                    setInnerHTML(this.hint, content)
+                    ankingsetInnerHTML(this.hint, content)
 
 
                     this.button.onclick = () => this.toggle()
@@ -264,7 +264,7 @@
 
         defineHintButton()
 
-        function setInnerHTML(elm, html) {
+        function ankingsetInnerHTML(elm, html) {
             elm.innerHTML = html;
             Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
                 const newScript = document.createElement("script");

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -3,9 +3,6 @@
     var RevealIncremental = "N";
     var ToggleAllOcclusions = ",";
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C";
-
     // ##############  BUTTON SETTINGS  ##############
     // All buttons will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,7 +1,12 @@
 <script>
    // ############## USER CONFIGURATION START ##############
    var autoflip = false // auto flip to back. Does not work for AnkiMobile.
-    // ############## USER CONFIGURATION END ##############
+
+
+   // ##############  TAG SHORTCUT  ##############
+   var toggleTagsShortcut = "C";
+   
+   // ############## USER CONFIGURATION END ##############
 </script>
 
 

--- a/Note Types/IO-one by one/README.md
+++ b/Note Types/IO-one by one/README.md
@@ -31,9 +31,8 @@ This note type **will** work on Anki iOS and AnkiDroid.
 
     ```
     // ##############  OCCLUSION SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var RevealIncremental = "78"; // n
-    var ToggleAllOcclusions = "188"; // ,
+    var RevealIncremental = "N";
+    var ToggleAllOcclusions = ",";
     ```
     </p>
   </details>

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -491,7 +491,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -3,24 +3,25 @@
 
 <script>
 var revealClozeShortcut = "N" // Shortcut to reveal next cloze
-var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next cloze word
+var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
 
-// Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word". 
-var revealNextMode = "cloze" 
+// Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+// "word" reveals word by word. 
+var revealNextClozeMode = "cloze" 
 
 // What cloze is hidden with
-var clozeHidden = (elem) => "👑"
+var clozeHider = (elem) => "👑"
 /* 
 You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
 
-// Fixed length  (default):
-var clozeHidden = (elem) => "███"
-// Replace all characters with "█":
-var clozeHidden = (elem) => "█".repeat(elem.textContent.length)
+// Fixed length:
+var clozeHider = (elem) => "███"
+// Replace each character with "█":
+var clozeHider = (elem) => "█".repeat(elem.textContent.length)
 // Show whitespaces:
-var clozeHidden = (elem) => "[" + elem.textContent.split(" ").map((t) => "_".repeat(t.length)).join(" ") + "]"
+var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
 // Color-filled box (doesn't hide images):
-var clozeHidden = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
 */
 
 // ~~~~~~~~~~~~~  HINT REVEAL SHORTCUTS  ~~~~~~~~~~~~~
@@ -89,27 +90,41 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 
-<!-- CLOZE ONE BY ONE SCRIPT -->
-<style>
-.cloze[data-content]:hover {
-  cursor: pointer;
-}
-</style>
-
+<!-- Shortcut Matcher Function -->
 <script>
-if (!window.shortcutMatcher) {
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
   // Returns function that match keyboard event to see if it matches given shortcut.
-  window.shortcutMatcher = function (shortcut) {
+  function shortcutMatcher(shortcut) {
     let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
     let mainKey = shortcutKeys[shortcutKeys.length - 1]
     if (mainKey.length === 1) {
-        let prepend = /\d/.test(mainKey) ? "digit" : "key"
-        mainKey = prepend + mainKey
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
     }
     let ctrl = shortcutKeys.includes("ctrl")
     let shift = shortcutKeys.includes("shift")
     let alt = shortcutKeys.includes("alt")
-
+  
     let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
       if (mainKey !== event.code.toLowerCase()) return false
       if (ctrl !== (event.ctrlKey || event.metaKey)) return false
@@ -120,130 +135,171 @@ if (!window.shortcutMatcher) {
     
     return matchShortcut
   }
-}
 </script>
 
+
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+.cloze[data-content]:hover {
+  cursor: pointer;
+}
+</style>
+
+
 <script>
-if (!window.revealCloze) {
-  window.hideCloze = function(cloze) {
-    cloze.dataset.content = cloze.innerHTML
-      if(window.clozeHints && window.clozeHints[i]) {
-          cloze.innerHTML = window.clozeHints[i]
-      } else {
-          cloze.innerHTML = clozeHidden(cloze)
-      }
-  }
+  (function() {
+    /*
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{ {One by one} }` === ""
+    } catch (exception) {
+      console.log(exception)
+    }
+    */
+    var clozeOneByOneEnabled = true 
   
-  window.revealCloze = function(elem) {
-    if (elem.dataset.content !== undefined) {
+    let hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    let revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
       elem.innerHTML = elem.dataset.content
       delete elem.dataset.content
     }
-  }
-
-  window.revealClozeWord = function(elem) {
-    if (elem.dataset.content === undefined) {
-      return
-    }
-    if (elem.dataset.hidden !== undefined) {
-      let words = elem.dataset.hidden.split(" ");
-      if (words.length == 1) {
-        revealCloze(elem)
-        delete elem.dataset.hidden
-        delete elem.dataset.revealed
+  
+    let revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
       } else {
-        elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-        elem.dataset.hidden = words.slice(1).join(" ");
         let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.hidden;
-        elem.innerHTML = elem.dataset.revealed + " " + clozeHidden(temp);
-      }
-    } else {
-      let temp = document.createElement("div");
-      temp.innerHTML = elem.dataset.content;
-      elem.dataset.hidden = temp.textContent;
-      elem.dataset.revealed = "";
-      revealClozeWord(elem)
-    }
-  }
-
-  window.revealNext = function() {
-    let nextHidden = document.querySelector(".cloze[data-content]")
-    if(!nextHidden) {
-        return
-    } 
-    if (revealNextMode === "word") {
-        revealClozeWord(nextHidden)
-    } else {
-        revealCloze(nextHidden)
-    }
-    return
-  }
-
-  window.toggleRevealAll = function() {
-    let elems = document.querySelectorAll(".cloze[data-content]")
-    let button = document.getElementById("button-toggle-all")
-    if(elems.length > 0) {
-      for (let i = 0; i < elems.length; i++) {
-          revealCloze(elems[i])
-      }
-    } else {
-      let elems = document.querySelectorAll(".cloze")
-      for (let i = 0; i < elems.length; i++) {
-      hideCloze(elems[i])
-      }
-    }
-  }
-
-  window.revealClozeClicked = function(ev) {
-    if (!ev.altKey && (revealNextMode !== "word")) {
-      revealCloze(ev.currentTarget)
-    } else {
-      revealClozeWord(ev.currentTarget)
-    }
-  }
-
-  document.addEventListener("keydown",  function(ev) {
-    let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
-    if(showAllShortcut(ev)) {
-      let elem = document.querySelector(".cloze[data-content]")
-      if (elem) {
-        revealCloze(elem)
-        ev.stopPropagation()
-        ev.preventDefault()
-        return
-      }
-    }
-    let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
-    if (showWordShortcut(ev)) {
-      let elem = document.querySelector(".cloze[data-content]")
-      if (elem) {
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
         revealClozeWord(elem)
-        ev.stopPropagation()
-        ev.preventDefault()
-        return
       }
     }
-  });
-
-}
-
-(function(){
-  try{
-    let clozes = document.getElementsByClassName("cloze")
-    for (let i = 0; i < clozes.length; i++) {
-      let cloze = clozes[i]
-      hideCloze(cloze)
-      cloze.addEventListener("touchend", revealClozeClicked)
-      cloze.addEventListener("click", revealClozeClicked)
-
+  
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
     }
-  } finally {
+  
+    let hideAllCloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+  
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+  
+    let revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+  
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    let attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+  
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+  
+  
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
     // autoflip hides card in front template
     document.getElementById("qa").style.removeProperty("display")
-  }
-})()
-
+    hideAllCloze(initial=true)
+  
+    attachKeydownListener()
+  })()
 </script>
 
 

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -416,6 +416,165 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
+<script>
+  (function() {
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
+    } catch (exception) {
+      console.log(exception)
+    }
+
+    const hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    const revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
+    }
+
+    const revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
+      }
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    const hideloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    const attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
+</script>
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -369,7 +369,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -420,7 +420,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -25,14 +25,12 @@ var clozeHider = (elem) => `<span style="background-color: red; color: transpare
 */
 
 // ~~~~~~~~~~~~~  HINT REVEAL SHORTCUTS  ~~~~~~~~~~~~~
-// Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-// The shortcuts are  Alt  +  the number/letter below
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
 var ButtonShortcuts = {
-    "Personal Notes" : '49', // alt + 1
-    "Missed Questions" : '50', // alt + 2
+    "Personal Notes" : "Alt + 1",
+    "Missed Questions" : "Alt + 2",
 }
-var ToggleAllButtons = '222' // '
+var ToggleAllButtonsShortcut = "'"
 
 // ~~~~~~~~~~~~~  SHOW HINTS AUTOMATICALLY  ~~~~~~~~~~~~~
 var ButtonAutoReveal = {
@@ -43,8 +41,7 @@ var ButtonAutoReveal = {
 var ScrollToButton = true;
 
 // ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
-// Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-var ToggleTags = "67"; // c
+var ToggleTagsShortcut = "C";
 
 //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
 var tagID = "XXXYYYZZZ"
@@ -365,10 +362,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                    this.toggle()
+                    }
                     return false
                 })
             }
@@ -449,8 +449,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -40,9 +40,6 @@ var ButtonAutoReveal = {
 
 var ScrollToButton = true;
 
-// ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
-var toggleTagsShortcut = "C";
-
 //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
 var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -69,9 +69,12 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 
 <!-- BUTTON FIELDS -->
-<button id="button-reveal-next" class="button-general" onclick="revealNext()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleRevealAll()">Toggle All</button>
-<br>
+
+<!-- ClOZE ONE BY ONE BUTTONS -->
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
+<br />
+
 <div class="btn-spacer" hidden></div>
 <hint-button field-name="Personal Notes" short="ln" hint-id="notes"></hint-button>
 <div id="dummy-ln" style="display: none;">{{Personal Notes}}</div>

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -86,6 +86,25 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 {{/Extra}}<br>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -223,8 +242,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -288,7 +307,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -364,7 +383,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                     this.toggle()
@@ -416,165 +435,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
-<!-- CLOZE ONE BY ONE SCRIPT -->
-<style>
-  .cloze[data-content]:hover {
-    cursor: pointer;
-  }
-</style>
-
-<script>
-  (function() {
-    var clozeOneByOneEnabled = true;
-    try {
-        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
-
-    const hideCloze = function(cloze) {
-      if (!clozeOneByOneEnabled) {
-        return
-      }
-      cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[i]) {
-            cloze.innerHTML = window.clozeHints[i]
-        } else {
-            cloze.innerHTML = clozeHider(cloze)
-        }
-    }
-    
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      delete elem.dataset.content
-    }
-
-    const revealClozeWord = function(elem) {
-      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-        }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
-      }
-    }
-
-    window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
-      if(!nextHidden) {
-          return
-      } 
-      if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
-      } else {
-          revealCloze(nextHidden)
-      }
-    }
-
-    const hideAllCloze = function(initial) {
-      let clozes = document.getElementsByClassName("cloze")
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
-        if (cloze.offsetWidth === 0) {
-          continue
-        }
-        hideCloze(cloze)
-        if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
-        }
-      }
-    }
-
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
-      if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
-        }
-      } else {
-        hideAllCloze(initial=false)
-      }
-    }
-
-    const revealClozeClicked = function(ev) {
-      let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (!ev.altKey && (revealNextClozeMode !== "word")) {
-        revealCloze(elem)
-      } else {
-        revealClozeWord(elem)
-      }
-      ev.stopPropagation()
-      ev.preventDefault()
-    }
-
-    // previously attached listener should be removed.
-    //
-    // In case the keydown listener changes between versions across notetypes
-    // and if shortcut is different across notetypes, attached every time.
-    const attachKeydownListener = function() {
-      if(window.revealClozeKeydownListener) {
-        document.removeEventListener("keydown", window.revealClozeKeydownListener)
-      }
-      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
-      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
-
-      window.revealClozeKeydownListener = function(ev) {
-        if(showAllShortcut(ev)) {
-          let elem = document.querySelector(".cloze[data-content]")
-          if (elem) {
-            revealCloze(elem)
-            ev.stopPropagation()
-            ev.preventDefault()
-            return
-          }
-        }
-        if (showWordShortcut(ev)) {
-          let elem = document.querySelector(".cloze[data-content]")
-          if (elem) {
-            revealClozeWord(elem)
-            ev.stopPropagation()
-            ev.preventDefault()
-            return
-          }
-        }
-      }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
-    }
-    
-    // autoflip hides card in front template
-    document.getElementById("qa").style.removeProperty("display")
-    hideAllCloze(initial=true)
-
-    attachKeydownListener()
-  })()
-</script>
-
-
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>
@@ -609,7 +469,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }
@@ -772,14 +632,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   }
   var pcc = document.getElementById("popup-container");
   var prevSel = "";
-  document.addEventListener('click', function () {
+  ankingAddEventListener(document, 'click', function () {
       var currentSelection = getSelectionText();
       if (currentSelection !== "") { prevSel = currentSelection; }
       if (currentSelection && !mustClickW) {
           getSummaryFor(currentSelection);
       } else { closePopup(); }
   });
-  document.addEventListener('keyup', function (e) {
+  ankingAddEventListener(document, 'keyup', function (e) {
       if (e.key == "w") {
           if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
       }

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Back Template.html
@@ -41,7 +41,7 @@ var ButtonAutoReveal = {
 var ScrollToButton = true;
 
 // ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
-var ToggleTagsShortcut = "C";
+var toggleTagsShortcut = "C";
 
 //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
 var tagID = "XXXYYYZZZ"
@@ -611,7 +611,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
         if (isShortcut(e)) {
             showtags();

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
@@ -59,6 +59,26 @@ if(autoflip) {
 </script>
 
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -179,7 +199,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
     }
 
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
@@ -128,7 +128,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
@@ -18,6 +18,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ~~~~~~~~~~~~~  TAG SHORTCUT  ~~~~~~~~~~~~~
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze one by one/Front Template.html
@@ -59,6 +59,53 @@ if(autoflip) {
 </script>
 
 
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
+
 <!-- COUNTDOWN TIMER -->
 <div class="timer" id="s2"></div>
 <script>
@@ -130,8 +177,10 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -16,9 +16,6 @@
 
     var ScrollToButton = true;
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C";
-
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -22,6 +22,28 @@
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 
+    // ~~~~~~~~~~~~~  CLOZE ONE BY ONE  ~~~~~~~~~~~~~
+    var revealClozeShortcut = "N" // Shortcut to reveal next cloze
+    var revealClozeWordShortcut = "Shift + N" // Shortcut to reveal next hidden word in cloze
+
+    // Changes how "Reveal Next" and clicking behaves. Either "cloze" or "word".
+    // "word" reveals word by word. 
+    var revealNextClozeMode = "cloze" 
+
+    // What cloze is hidden with
+    var clozeHider = (elem) => "👑"
+    /* 
+    You can replace the above line with below examples. '█' or '_' works well for hiding clozes.
+
+    // Fixed length:
+    var clozeHider = (elem) => "███"
+    // Replace each character with "█":
+    var clozeHider = (elem) => "█".repeat(elem.textContent.length)
+    // Show whitespaces:
+    var clozeHider = (elem) => "[" + elem.textContent.split(" ").map((t) => "█".repeat(t.length)).join(" ") + "]"
+    // Color-filled box (doesn't hide images):
+    var clozeHider = (elem) => `<span style="background-color: red; color: transparent;">${elem.innerHTML}</span>`
+    */
 </script>
 
 <div class="clozefield" id="text">{{cloze:Text}}</div>
@@ -297,7 +319,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
     }
 
-    const hideloze = function(initial) {
+    const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       for (let i = 0; i < clozes.length; i++) {
         let cloze = clozes[i]

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -1,14 +1,12 @@
  <script>
     // ##############  BUTTON REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Personal Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
+        "Personal Notes" : "Alt + 1",
+        "Missed Questions" : "Alt + 2"
     }
 
-    var ToggleAllButtons = '222' // '
+    var ToggleAllButtonsShortcut = "'"
 
     // ##############  SHOW BUTTON HINTS AUTOMATICALLY  ##############
     var ButtonAutoReveal = {
@@ -19,8 +17,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -64,6 +61,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <!-- PHYSEO HYPERLINK IMAGE -->
 <a href="https://www.physeo.com"><img src="_PhyseoRoundLogo.png" alt="Physeo" id="pic"></a>
 
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>  
+  
 
 <!-- TOGGLE BUTTONS -->
 <script>
@@ -123,10 +168,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                     this.toggle()
                 }
 
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                    this.toggle()
+                    }
                     return false
                 })
             }
@@ -207,8 +255,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -88,6 +88,26 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <!-- PHYSEO HYPERLINK IMAGE -->
 <a href="https://www.physeo.com"><img src="_PhyseoRoundLogo.png" alt="Physeo" id="pic"></a>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -197,7 +217,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
                 var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                 var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                document.addEventListener("keydown", (evt) => {
+                ankingAddEventListener(document, "keydown", (evt) => {
                     if (evt.repeat) return
                     if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                     this.toggle()
@@ -333,8 +353,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         hideCloze(cloze)
         if (initial === true) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
+          ankingAddEventListener(cloze, "touchend", revealClozeClicked)
+          ankingAddEventListener(cloze, "click", revealClozeClicked)
         }
       }
     }
@@ -396,7 +416,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
           }
         }
       }
-      document.addEventListener("keydown", window.revealClozeKeydownListener);
+      ankingAddEventListener(document, "keydown", window.revealClozeKeydownListener);
     }
     
     // autoflip hides card in front template
@@ -443,7 +463,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
     }
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }
@@ -607,14 +627,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     }
     var pcc = document.getElementById("popup-container");
     var prevSel = "";
-    document.addEventListener('click', function () {
+    ankingAddEventListener(document, 'click', function () {
         var currentSelection = getSelectionText();
         if (currentSelection !== "") { prevSel = currentSelection; }
         if (currentSelection && !mustClickW) {
             getSummaryFor(currentSelection);
         } else { closePopup(); }
     });
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (e.key == "w") {
             if (pcc.style.display === "block") { closePopup(); } else { getSummaryFor(prevSel); }
         }

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -203,7 +203,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -254,7 +254,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -17,7 +17,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -445,7 +445,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
         if (isShortcut(e)) {
             showtags();

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -65,6 +65,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <hr>
 
 <!-- BUTTON FIELDS -->
+
+<!-- ClOZE ONE BY ONE BUTTONS -->
+{{#One by one}}
+<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next Cloze</button>
+<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All Cloze</button>
+<br />
+{{/One by one}}
+
 {{#Personal Notes}}<hint-button field-name="Personal Notes" short="ln" hint-id="notes"></hint-button>
 <div id="dummy-ln" style="display: none;">{{edit:Personal Notes}}</div>{{/Personal Notes}}
 

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Back Template.html
@@ -222,6 +222,166 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 </script>
 
 
+<!-- CLOZE ONE BY ONE SCRIPT -->
+<style>
+  .cloze[data-content]:hover {
+    cursor: pointer;
+  }
+</style>
+
+<script>
+  (function() {
+    var clozeOneByOneEnabled = true;
+    try {
+        clozeOneByOneEnabled = `{{One by one}}`.trim() !== ""
+    } catch (exception) {
+      console.log(exception)
+    }
+
+    const hideCloze = function(cloze) {
+      if (!clozeOneByOneEnabled) {
+        return
+      }
+      cloze.dataset.content = cloze.innerHTML
+        if(window.clozeHints && window.clozeHints[i]) {
+            cloze.innerHTML = window.clozeHints[i]
+        } else {
+            cloze.innerHTML = clozeHider(cloze)
+        }
+    }
+    
+    const revealCloze = function(elem) {
+      // Checking for dataset.content is undefined may not be needed anymore?
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      elem.innerHTML = elem.dataset.content
+      delete elem.dataset.content
+    }
+
+    const revealClozeWord = function(elem) {
+      if (!clozeOneByOneEnabled || elem.dataset.content === undefined) {
+        return
+      }
+      if (elem.dataset.hidden !== undefined) {
+        let words = elem.dataset.hidden.split(" ");
+        if (words.length == 1) {
+          revealCloze(elem)
+          delete elem.dataset.hidden
+          delete elem.dataset.revealed
+        } else {
+          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
+          elem.dataset.hidden = words.slice(1).join(" ");
+          let temp = document.createElement("div");
+          temp.innerHTML = elem.dataset.hidden;
+          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
+        }
+      } else {
+        let temp = document.createElement("div");
+        temp.innerHTML = elem.dataset.content;
+        elem.dataset.hidden = temp.textContent;
+        elem.dataset.revealed = "";
+        revealClozeWord(elem)
+      }
+    }
+
+    window.revealNextCloze = function() {
+      let nextHidden = document.querySelector(".cloze[data-content]")
+      if(!nextHidden) {
+          return
+      } 
+      if (revealNextClozeMode === "word") {
+          revealClozeWord(nextHidden)
+      } else {
+          revealCloze(nextHidden)
+      }
+    }
+
+    const hideloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      for (let i = 0; i < clozes.length; i++) {
+        let cloze = clozes[i]
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        hideCloze(cloze)
+        if (initial === true) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze[data-content]")
+      let button = document.getElementById("button-toggle-all")
+      if(elems.length > 0) {
+        for (let i = 0; i < elems.length; i++) {
+            revealCloze(elems[i])
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (elem.dataset.content === undefined) {
+        return
+      }
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
+    // previously attached listener should be removed.
+    //
+    // In case the keydown listener changes between versions across notetypes
+    // and if shortcut is different across notetypes, attached every time.
+    const attachKeydownListener = function() {
+      if(window.revealClozeKeydownListener) {
+        document.removeEventListener("keydown", window.revealClozeKeydownListener)
+      }
+      let showAllShortcut = shortcutMatcher(window.revealClozeShortcut)
+      let showWordShortcut = shortcutMatcher(window.revealClozeWordShortcut)
+
+      window.revealClozeKeydownListener = function(ev) {
+        if(showAllShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealCloze(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+        if (showWordShortcut(ev)) {
+          let elem = document.querySelector(".cloze[data-content]")
+          if (elem) {
+            revealClozeWord(elem)
+            ev.stopPropagation()
+            ev.preventDefault()
+            return
+          }
+        }
+      }
+      document.addEventListener("keydown", window.revealClozeKeydownListener);
+    }
+    
+    // autoflip hides card in front template
+    document.getElementById("qa").style.removeProperty("display")
+    hideAllCloze(initial=true)
+
+    attachKeydownListener()
+  })()
+</script>
+
+
+
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
 <div id="tags-container">{{clickable::Tags}}</div>

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
@@ -88,7 +88,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
@@ -15,6 +15,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     var seconds = 9
     var timeOverMsg = "<span style='color:#CC5B5B'>!<br/>!<br/>!<br/>!<br/>!<br/>!</span>"
 
+    // ##############  TAG SHORTCUT  ##############
+    var toggleTagsShortcut = "C";
+
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
 

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
@@ -55,7 +55,54 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 
 <!-- PHYSEO HYPERLINK IMAGE -->
 <a href="https://www.physeo.com"><img src="_PhyseoRoundLogo.png" alt="Physeo" id="pic"></a>
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
     
+    return matchShortcut
+  }
+</script>
+
 
 <!-- CLICKABLE COLORFUL TAGS -->
 {{#Tags}}
@@ -90,8 +137,10 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == toggleTagsShortcut) {
+        if (isShortcut(e)) {
             showtags();
         }
     });

--- a/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-Cloze/Front Template.html
@@ -56,6 +56,26 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
 <!-- PHYSEO HYPERLINK IMAGE -->
 <a href="https://www.physeo.com"><img src="_PhyseoRoundLogo.png" alt="Physeo" id="pic"></a>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
+
 <!-- Shortcut Matcher Function -->
 <script>
   var specialCharCodes = {
@@ -139,7 +159,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
     }
 
     var isShortcut = shortcutMatcher(toggleTagsShortcut)
-    document.addEventListener('keyup', function (e) {
+    ankingAddEventListener(document, 'keyup', function (e) {
         if (isShortcut(e)) {
             showtags();
         }

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
@@ -3,9 +3,6 @@
     var RevealIncrementalShortcut = "N";
     var ToggleAllOcclusionsShortcut = ",";
 
-    // ##############  TAG SHORTCUT  ##############
-    var toggleTagsShortcut = "C";
-
     // ##############  BUTTON SETTINGS  ##############
     // All buttons will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
@@ -4,7 +4,7 @@
     var ToggleAllOcclusionsShortcut = ",";
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     // ##############  BUTTON SETTINGS  ##############
     // All buttons will also open with "H" if using the Hint Hotkeys add-on 
@@ -137,7 +137,7 @@
         }
         if (!globalThis.ToggleTagsListening) {
             globalThis.ToggleTagsListening = true
-            var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+            var isShortcut = shortcutMatcher(toggleTagsShortcut)
             document.addEventListener('keydown', function (e) {
                 if (e.repeat) return
                 if (isShortcut(e)) {

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
@@ -51,6 +51,25 @@
 <!-- PHYSEO HYPERLINK IMAGE -->
 <a href="https://www.physeo.com"><img src="_PhyseoRoundLogo.png" alt="Physeo" id="pic"></a>
 
+<!-- NOT-PERSISTING EVENT LISTENER -->
+<script>
+  if (window.ankingEventListeners) {
+    for (const listener of ankingEventListeners) {
+      const target = listener[0]
+      const type = listener[1]
+      const handler = listener[2]
+      if(target && target.removeEventListener) {
+        target.removeEventListener(type, handler)
+      }
+    }
+  }
+  window.ankingEventListeners = []
+  
+  window.ankingAddEventListener = function(target, type, handler) {
+    target.addEventListener(type, handler)
+    window.ankingEventListeners.push([target, type, handler])
+  }
+</script>
 
 <!-- Shortcut Matcher Function -->
 <script>
@@ -135,7 +154,7 @@
         if (!globalThis.ToggleTagsListening) {
             globalThis.ToggleTagsListening = true
             var isShortcut = shortcutMatcher(toggleTagsShortcut)
-            document.addEventListener('keydown', function (e) {
+            ankingAddEventListener(document, 'keydown', function (e) {
                 if (e.repeat) return
                 if (isShortcut(e)) {
                     toggleTags();
@@ -205,7 +224,7 @@
 
                     var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
                     var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
-                    document.addEventListener("keydown", (evt) => {
+                    ankingAddEventListener(document, "keydown", (evt) => {
                         if (evt.repeat) return
                         if (isShortcut(evt) || isToggleAllShortcut(evt)) {
                         this.toggle()

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
@@ -1,22 +1,19 @@
 <script>
     // ##############  OCCLUSION SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var RevealIncremental = "78"; // n
-    var ToggleAllOcclusions = "188"; // ,
+    var RevealIncrementalShortcut = "N";
+    var ToggleAllOcclusionsShortcut = ",";
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
     // ##############  BUTTON SETTINGS  ##############
-    // The button shortcuts are  Alt + the number/letter the keycode stands for
     // All buttons will also open with "H" if using the Hint Hotkeys add-on 
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
     var ButtonShortcuts = {
-        "Extra": '49', // alt + 1
-        "Personal Notes": '50', // alt + 2
-        "Missed Questions": '51', // alt + 3
+        "Extra": "Alt + 1",
+        "Personal Notes": "Alt + 2",
+        "Missed Questions": "Alt + 3",
     }
+    var ToggleAllButtonsShortcut = "'"
 
     // change values from false to true to have the fields revealed from the start
     var ButtonAutoReveal = {
@@ -25,7 +22,6 @@
         "Missed Questions": false,
     }
 
-    var ToggleAllButtons = '222' // '
     var ScrollToButton = true
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
@@ -58,6 +54,53 @@
 <!-- PHYSEO HYPERLINK IMAGE -->
 <a href="https://www.physeo.com"><img src="_PhyseoRoundLogo.png" alt="Physeo" id="pic"></a>
 
+
+<!-- Shortcut Matcher Function -->
+<script>
+  var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 <div id="anki-am" data-name="Assets by ASSET MANAGER" data-version="2.1">
 
@@ -94,10 +137,10 @@
         }
         if (!globalThis.ToggleTagsListening) {
             globalThis.ToggleTagsListening = true
-            document.addEventListener('keydown', function (evt) {
-                if (evt.repeat) return
-                evt = evt || window.event
-                if (evt.keyCode == ToggleTags) {
+            var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+            document.addEventListener('keydown', function (e) {
+                if (e.repeat) return
+                if (isShortcut(e)) {
                     toggleTags();
                 }
             });
@@ -163,10 +206,13 @@
                         this.toggle()
                     }
 
+                    var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                    var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                     document.addEventListener("keydown", (evt) => {
                         if (evt.repeat) return
-                        if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                        if (evt.keyCode == ToggleAllButtons) this.toggle()
+                        if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                        this.toggle()
+                        }
                         return false
                     })
                 }
@@ -231,13 +277,14 @@
                         rect.addEventListener("click", reveal)
                     }
                     if (!globalThis.AnKingIOListening) {
+                        var isRevealIncrementalScut = shortcutMatcher(RevealIncrementalShortcut)
+                        var isToggleAllOcclScut = shortcutMatcher(ToggleAllOcclusionsShortcut)
                         document.addEventListener("keydown", (evt) => {
                             if (evt.repeat) return
-                            evt = evt || window.event
-                            if (evt.keyCode == RevealIncremental) {
+                            if (isRevealIncrementalScut(evt)) {
                                 toggleNext()
                             }
-                            else if (evt.keyCode == ToggleAllOcclusions) {
+                            else if (isToggleAllOcclScut(evt)) {
                                 toggleAll()
                             }
                         })

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/Back Template.html
@@ -210,7 +210,7 @@
                     }
 
                     // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                    setInnerHTML(this.hint, content)
+                    ankingsetInnerHTML(this.hint, content)
 
 
                     this.button.onclick = () => this.toggle()
@@ -261,7 +261,7 @@
 
         defineHintButton()
 
-        function setInnerHTML(elm, html) {
+        function ankingsetInnerHTML(elm, html) {
             elm.innerHTML = html;
             Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
                 const newScript = document.createElement("script");

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/Front Template.html
@@ -1,6 +1,10 @@
 <script>
    // ############## USER CONFIGURATION START ##############
    var autoflip = false // auto flip to back. Does not work for AnkiMobile.
+
+   // ##############  TAG SHORTCUT  ##############
+   var toggleTagsShortcut = "C";
+
     // ############## USER CONFIGURATION END ##############
 </script>
 

--- a/Note Types/Physeo Note Types/Physeo-IO one by one/README.md
+++ b/Note Types/Physeo Note Types/Physeo-IO one by one/README.md
@@ -31,9 +31,8 @@ This note type **will** work on Anki iOS and AnkiDroid.
 
     ```
     // ##############  OCCLUSION SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var RevealIncremental = "78"; // n
-    var ToggleAllOcclusions = "188"; // ,
+    var RevealIncremental = "N";
+    var ToggleAllOcclusions = ",";
     ```
     </p>
   </details>

--- a/Note Types/shared templates/Back Template.html
+++ b/Note Types/shared templates/Back Template.html
@@ -17,7 +17,7 @@
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -258,7 +258,7 @@ var specialCharCodes = {
         }
     }
 
-    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
+    var isShortcut = shortcutMatcher(toggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
         if (isShortcut(e)) {
             showtags();

--- a/Note Types/shared templates/Back Template.html
+++ b/Note Types/shared templates/Back Template.html
@@ -158,7 +158,7 @@ var specialCharCodes = {
                 }
 
                 // ... this also runs script tags, this makes it compatible with the Edit Field during Review add-on
-                setInnerHTML(this.hint, content)
+                ankingsetInnerHTML(this.hint, content)
 
 
                 this.button.onclick = () => this.toggle()
@@ -209,7 +209,7 @@ var specialCharCodes = {
 
     defineHintButton()
 
-    function setInnerHTML(elm, html) {
+    function ankingsetInnerHTML(elm, html) {
         elm.innerHTML = html;
         Array.from(elm.querySelectorAll("script")).forEach(oldScript => {
             const newScript = document.createElement("script");

--- a/Note Types/shared templates/Back Template.html
+++ b/Note Types/shared templates/Back Template.html
@@ -1,25 +1,23 @@
 <script>
     // ##############  HINT REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Lecture Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
+        "Personal Notes": "Alt + 1",
+        "Missed Questions": "Alt + 2",
     }
-    var ToggleAllButtons = '222' // '
+
+    var ToggleAllButtonsShortcut = "'"
 
     // ##############  SHOW HINTS AUTOMATICALLY  ##############
     var ButtonAutoReveal = {
-        "Lecture Notes" : false,
-        "Missed Questions" : false,
+        "Personal Notes": false,
+        "Missed Questions": false,
     }
 
     var ScrollToButton = true;
 
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
 
     //ENTER THE TAG TERM WHICH, WHEN PRESENT, WILL TRIGGER A RED BACKGROUND
     var tagID = "XXXYYYZZZ"
@@ -64,6 +62,54 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- ANKING HYPERLINK IMAGE -->
 <a href="https://www.ankingmed.com"><img src="_AnKingRound.png" alt="The AnKing" id="pic"></a>
+
+
+<!-- Shortcut Matcher Function -->
+<script>
+var specialCharCodes = {
+    "-": "minus",
+    "=": "equal",
+    "[": "bracketleft",
+    "]": "bracketright",
+    ";": "semicolon",
+    "'": "quote",
+    "`": "backquote",
+    "\\": "backslash",
+    ",": "comma",
+    ".": "period",
+    "/": "slash",
+  };
+  // Returns function that match keyboard event to see if it matches given shortcut.
+  function shortcutMatcher(shortcut) {
+    let shortcutKeys = shortcut.toLowerCase().split(/[+]/).map(key => key.trim())
+    let mainKey = shortcutKeys[shortcutKeys.length - 1]
+    if (mainKey.length === 1) {
+      if (/\d/.test(mainKey)) {
+        mainKey = "digit" + mainKey
+      } else if (/[a-zA-Z]/.test(mainKey)) {
+        mainKey = "key" + mainKey
+      } else {
+        let code = specialCharCodes[mainKey];
+        if (code) {
+          mainKey = code
+        }
+      }
+    }
+    let ctrl = shortcutKeys.includes("ctrl")
+    let shift = shortcutKeys.includes("shift")
+    let alt = shortcutKeys.includes("alt")
+  
+    let matchShortcut = function (ctrl, shift, alt, mainKey, event) {
+      if (mainKey !== event.code.toLowerCase()) return false
+      if (ctrl !== (event.ctrlKey || event.metaKey)) return false
+      if (shift !== event.shiftKey) return false
+      if (alt !== event.altKey) return false
+      return true
+    }.bind(window, ctrl, shift, alt, mainKey)
+    
+    return matchShortcut
+  }
+</script>
 
 
 <!-- TOGGLE BUTTONS -->
@@ -123,11 +169,14 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 if (ButtonAutoReveal[fieldName]) {
                     this.toggle()
                 }
-
+                
+                var isShortcut = shortcutMatcher(ButtonShortcuts[fieldName])
+                var isToggleAllShortcut = shortcutMatcher(ToggleAllButtonsShortcut)
                 document.addEventListener("keydown", (evt) => {
                     if (evt.repeat) return
-                    if (evt.altKey && evt.keyCode == ButtonShortcuts[fieldName]) this.toggle()
-                    if (evt.keyCode == ToggleAllButtons) this.toggle()
+                    if (isShortcut(evt) || isToggleAllShortcut(evt)) {
+                    this.toggle()
+                    }
                     return false
                 })
             }
@@ -208,12 +257,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
                 "none";
         }
     }
+
+    var isShortcut = shortcutMatcher(ToggleTagsShortcut)
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (isShortcut(e)) {
             showtags();
         }
     });
-
 
 </script>
 {{/Tags}}

--- a/Note Types/shared templates/Front Template.html
+++ b/Note Types/shared templates/Front Template.html
@@ -95,7 +95,7 @@ countdown("s2", minutes, seconds ); //2nd value is the minute, 3rd is the second
         }
     }
     document.addEventListener('keyup', function (e) {
-        if (e.keyCode == ToggleTags) {
+        if (e.keyCode == toggleTagsShortcut) {
             showtags();
         }
     });

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All note types in this repo use many or all of the features listed below. Some w
     Default is `C`
     ```
     // ##############  TAG SHORTCUT  ##############
-    var ToggleTagsShortcut = "C";
+    var toggleTagsShortcut = "C";
     ```
     </p>
   </details>

--- a/README.md
+++ b/README.md
@@ -79,11 +79,10 @@ All note types in this repo use many or all of the features listed below. Some w
   <details><summary>Toggle on/off with shortcut <i>(Back template)</i></summary>
     <p>
 
-    Default is `c`
+    Default is `C`
     ```
     // ##############  TAG SHORTCUT  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    var ToggleTags = "67"; // c
+    var ToggleTagsShortcut = "C";
     ```
     </p>
   </details>
@@ -112,14 +111,12 @@ All note types in this repo use many or all of the features listed below. Some w
 
     ```
     // ##############  HINT REVEAL SHORTCUTS  ##############
-    // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
-    // The shortcuts are  Alt  +  the number/letter below
     // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
     var ButtonShortcuts = {
-        "Lecture Notes" : '49', // alt + 1
-        "Missed Questions" : '50', // alt + 2
+        "Lecture Notes" : "Alt + 1",
+        "Missed Questions" : "Alt + 2",
     }
-    var ToggleAllButtons = '222' // '
+    var ToggleAllButtons = "'"
     ```
     </p>
   </details>


### PR DESCRIPTION
1. Adds Cloze one by one. As an optional field for cloze note types that isn't `Cloze One by One` and `Physeo cloze one by one`
2. Fix event listeners persisting: new listeners being attached per each card side.
3. Natural shortcut string support
4. Fix name collision with existing anki function: renamed `setInnerHTML` to `ankingSetInnerHTML`