### PR TITLE
npm build github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build Note Type
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Note Type
+        run: npm run build
+
+      - name: Commit and push changes to git
+        uses: EndBug/add-and-commit@v7.4.0
+        with:
+          message: "npm build"
+          committer_name: github-actions
+          committer_email: actions@github.com


### PR DESCRIPTION
Automatically runs `npm build` for each pushed commit.

Tested here: https://github.com/BlueGreenMagick/AnKing-Note-Types/commits/gh-build-act-new