### PR TITLE
Add CSS for lists for better readability

### DIFF
--- a/src/notetypes/AnKing/Styling.css
+++ b/src/notetypes/AnKing/Styling.css
@@ -257,6 +257,33 @@ img:active {
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/AnKingDerm/Styling.css
+++ b/src/notetypes/AnKingDerm/Styling.css
@@ -243,6 +243,33 @@ img:active {
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/AnKingMCAT/Styling.css
+++ b/src/notetypes/AnKingMCAT/Styling.css
@@ -259,6 +259,33 @@ hr { opacity: .7 }
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/AnKingOverhaul/Styling.css
+++ b/src/notetypes/AnKingOverhaul/Styling.css
@@ -316,6 +316,33 @@ hr { opacity: .7 }
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/Basic-AnKing/Styling.css
+++ b/src/notetypes/Basic-AnKing/Styling.css
@@ -195,6 +195,33 @@ hr { opacity: .7 }
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/Basic-AnKingLanguage/Styling.css
+++ b/src/notetypes/Basic-AnKingLanguage/Styling.css
@@ -209,6 +209,33 @@ hr { opacity: .7 }
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/IO-one by one/Styling.css
+++ b/src/notetypes/IO-one by one/Styling.css
@@ -146,6 +146,43 @@ i {
 }
 
 
+/* ~~~~~~~MNEMONICS LEFT JUSTIFIED~~~~~~~ */
+.mnemonics {
+  display: inline-block;
+  text-align: left; /* can change to center to 'turn off' this feature */
+}
+.centerbox {
+  text-align: center;
+}
+
+
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {
@@ -172,16 +209,6 @@ i {
 .qtip img {
   max-width: 95% !important;
   max-height: 95% !important;
-}
-
-
-/* ~~~~~~~MNEMONICS LEFT JUSTIFIED~~~~~~~ */
-.mnemonics {
-  display: inline-block;
-  text-align: left; /* can change to center to 'turn off' this feature */
-}
-.centerbox {
-  text-align: center;
 }
 
 

--- a/src/notetypes/Physeo-Cloze/Styling.css
+++ b/src/notetypes/Physeo-Cloze/Styling.css
@@ -227,6 +227,33 @@ hr { opacity: .7 }
 }
 
 
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {

--- a/src/notetypes/Physeo-IO one by one/Styling.css
+++ b/src/notetypes/Physeo-IO one by one/Styling.css
@@ -146,6 +146,43 @@ i {
 }
 
 
+/* ~~~~~~~MNEMONICS LEFT JUSTIFIED~~~~~~~ */
+.mnemonics {
+  display: inline-block;
+  text-align: left; /* can change to center to 'turn off' this feature */
+}
+.centerbox {
+  text-align: center;
+}
+
+
+/* ~~~~~~~~~ LISTS ~~~~~~~~~ */
+ul {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+ol {
+  padding-left: 40px;
+  display: inline-block;
+  max-width: 50%;
+  margin: auto;
+  text-align: left;
+}
+.mobile ul {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+.mobile ol {
+  display: inline-block;
+  text-align: left; 
+  max-width: 100%;
+}
+
+
 /* ~~~~~~~~~ ADD-ON CONFIGURATIONS ~~~~~~~~~ */
 /*Compatibility with Image Style Editor add-on*/
 .card {
@@ -172,16 +209,6 @@ i {
 .qtip img {
   max-width: 95% !important;
   max-height: 95% !important;
-}
-
-
-/* ~~~~~~~MNEMONICS LEFT JUSTIFIED~~~~~~~ */
-.mnemonics {
-  display: inline-block;
-  text-align: left; /* can change to center to 'turn off' this feature */
-}
-.centerbox {
-  text-align: center;
 }
 
 


### PR DESCRIPTION
- Lists
  - Desktop: text is in center, but left aligned with bullets lined up.
  - Mobile:  text and bullets are left-aligned.
- Rearranged a couple sections in the IO card stylings to match the order of other cards.

PR was created as per Nick @AnKingMed.


Screenshots:
<img src="https://user-images.githubusercontent.com/68623691/156691348-8ba5bdf4-4d41-410a-8525-caf3e1bf6cc1.png" width="500">
<img src="https://user-images.githubusercontent.com/68623691/156691570-a5773c7d-731a-4de7-895f-a1af95081244.png" width="500">

