### PR TITLE
Prevent coloring of empty links

### DIFF
--- a/src/notetypes/AnKing/Styling.css
+++ b/src/notetypes/AnKing/Styling.css
@@ -97,6 +97,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/AnKingDerm/Styling.css
+++ b/src/notetypes/AnKingDerm/Styling.css
@@ -111,6 +111,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/AnKingMCAT/Styling.css
+++ b/src/notetypes/AnKingMCAT/Styling.css
@@ -114,6 +114,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/AnKingOverhaul/Styling.css
+++ b/src/notetypes/AnKingOverhaul/Styling.css
@@ -140,6 +140,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/Basic-AnKing/Styling.css
+++ b/src/notetypes/Basic-AnKing/Styling.css
@@ -90,6 +90,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/Basic-AnKingLanguage/Styling.css
+++ b/src/notetypes/Basic-AnKingLanguage/Styling.css
@@ -89,6 +89,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/IO-one by one/Styling.css
+++ b/src/notetypes/IO-one by one/Styling.css
@@ -68,8 +68,6 @@ img {
   --active-rect-bg: salmon;
   --active-rect-border: yellow;
 }
-
-
 /* Default Text Color */
 .card {
   color: black;
@@ -85,6 +83,11 @@ img {
 /* Missed Questions Hint Reveal Color */
 #missed {
   color: red;
+}
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
 }
 
 

--- a/src/notetypes/Physeo-Cloze/Styling.css
+++ b/src/notetypes/Physeo-Cloze/Styling.css
@@ -95,6 +95,11 @@ img {
 .timer {
   color: transparent;
 }
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /*~~~~~~~~NIGHT MODE COLORS~~~~~~~~*/

--- a/src/notetypes/Physeo-IO one by one/Styling.css
+++ b/src/notetypes/Physeo-IO one by one/Styling.css
@@ -68,8 +68,6 @@ img {
   --active-rect-bg: salmon;
   --active-rect-border: yellow;
 }
-
-
 /* Default Text Color */
 .card {
   color: #56868a;
@@ -85,6 +83,11 @@ img {
 /* Missed Questions Hint Reveal Color */
 #missed {
   color: #ff684d;
+}
+/* Empty Link Color */
+a:not([href]) {
+  text-decoration: none;
+  color: inherit;
 }
 
 


### PR DESCRIPTION
Prevents coloring of empty links (`<a>` tags without href), which is created when text is copy/pasted from web sites.