### PR TITLE
Prevent coloring of links to javascript.

### DIFF
--- a/Note Types/AnKing/Styling.css
+++ b/Note Types/AnKing/Styling.css
@@ -98,7 +98,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/AnKingDerm/Styling.css
+++ b/Note Types/AnKingDerm/Styling.css
@@ -112,7 +112,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/AnKingMCAT/Styling.css
+++ b/Note Types/AnKingMCAT/Styling.css
@@ -115,7 +115,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/AnKingOverhaul/Styling.css
+++ b/Note Types/AnKingOverhaul/Styling.css
@@ -153,7 +153,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/Basic-AnKing/Styling.css
+++ b/Note Types/Basic-AnKing/Styling.css
@@ -91,7 +91,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/Basic-AnKingLanguage/Styling.css
+++ b/Note Types/Basic-AnKingLanguage/Styling.css
@@ -90,7 +90,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/IO-one by one/Styling.css
+++ b/Note Types/IO-one by one/Styling.css
@@ -85,7 +85,8 @@ img {
   color: red;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/Physeo-Cloze/Styling.css
+++ b/Note Types/Physeo-Cloze/Styling.css
@@ -96,7 +96,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/Note Types/Physeo-IO one by one/Styling.css
+++ b/Note Types/Physeo-IO one by one/Styling.css
@@ -85,7 +85,8 @@ img {
   color: #ff684d;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/AnKing/Styling.css
+++ b/src/notetypes/AnKing/Styling.css
@@ -98,7 +98,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/AnKingDerm/Styling.css
+++ b/src/notetypes/AnKingDerm/Styling.css
@@ -112,7 +112,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/AnKingMCAT/Styling.css
+++ b/src/notetypes/AnKingMCAT/Styling.css
@@ -115,7 +115,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/AnKingOverhaul/Styling.css
+++ b/src/notetypes/AnKingOverhaul/Styling.css
@@ -153,7 +153,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/Basic-AnKing/Styling.css
+++ b/src/notetypes/Basic-AnKing/Styling.css
@@ -91,7 +91,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/Basic-AnKingLanguage/Styling.css
+++ b/src/notetypes/Basic-AnKingLanguage/Styling.css
@@ -90,7 +90,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/IO-one by one/Styling.css
+++ b/src/notetypes/IO-one by one/Styling.css
@@ -85,7 +85,8 @@ img {
   color: red;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/Physeo-Cloze/Styling.css
+++ b/src/notetypes/Physeo-Cloze/Styling.css
@@ -96,7 +96,8 @@ img {
   color: transparent;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }

--- a/src/notetypes/Physeo-IO one by one/Styling.css
+++ b/src/notetypes/Physeo-IO one by one/Styling.css
@@ -85,7 +85,8 @@ img {
   color: #ff684d;
 }
 /* Empty Link Color */
-a:not([href]) {
+a:not([href]),
+a[href^="javascript:"] {
   text-decoration: none;
   color: inherit;
 }


### PR DESCRIPTION
Similar to #57. When copy/pasting from UW, user could get `<a href="javascript:void(0)"></a>` links pasted into Anki. This commit prevents the coloring of those type of links so they looks like any other text. If javascript links are ever used in Anki cards, the matching could be tweaked for more specific scenarios.