### PR TITLE
fix conflict between cloze 1by1 and edit field during review cloze

### DIFF
--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -74,12 +74,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- BUTTON FIELDS -->
 <!-- ClOZE ONE BY ONE BUTTONS -->
-{{#One by one}}
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
-<br />
-{{/One by one}}
 
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
+<div id="1by1-btns" style="display: none;">
+  <button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+  <button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+</div>
+
+<script>
+  (() => {
+    let clozeOneByOneEnabled = true;
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
+    
+    if (clozeOneByOneEnabled) {
+      document.getElementById("1by1-btns").style.display = "block";
+    }
+    })()
+  </script>
 
 {{#Personal Notes}}
 <span id = "hint-ln" class="hintBtn" data-name="Personal Notes">
@@ -265,11 +277,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <script>
   (function() {
     var clozeOneByOneEnabled = true;
-    try {
-        clozeOneByOneEnabled = `{{One by one}}` !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
 
     if (!clozeOneByOneEnabled) {
       return

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -34,13 +34,11 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
-  try {
-    clozeOneByOneEnabled = `{{One by one}}` !== ""
-  } catch (exception) {
-    console.log(exception)
-  }
+    clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
   
   window.clozeHints = [];
   if (clozeOneByOneEnabled) {

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -80,12 +80,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- BUTTON FIELDS -->
 <!-- ClOZE ONE BY ONE BUTTONS -->
-{{#One by one}}
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
-<br />
-{{/One by one}}
 
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
+<div id="1by1-btns" style="display: none;">
+  <button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+  <button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+</div>
+
+<script>
+  (() => {
+    let clozeOneByOneEnabled = true;
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
+    
+    if (clozeOneByOneEnabled) {
+      document.getElementById("1by1-btns").style.display = "block";
+    }
+    })()
+  </script>
 
 {{#Personal Notes}}
 <span id = "hint-ln" class="hintBtn" data-name="Personal Notes">
@@ -296,11 +308,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <script>
   (function() {
     var clozeOneByOneEnabled = true;
-    try {
-        clozeOneByOneEnabled = `{{One by one}}` !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
 
     if (!clozeOneByOneEnabled) {
       return

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -35,13 +35,11 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
-  try {
-    clozeOneByOneEnabled = `{{One by one}}` !== ""
-  } catch (exception) {
-    console.log(exception)
-  }
+    clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
   
   window.clozeHints = [];
   if (clozeOneByOneEnabled) {

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -77,12 +77,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- BUTTON FIELDS -->
 <!-- ClOZE ONE BY ONE BUTTONS -->
-{{#One by one}}
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
-<br />
-{{/One by one}}
 
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
+<div id="1by1-btns" style="display: none;">
+  <button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+  <button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+</div>
+
+<script>
+  (() => {
+    let clozeOneByOneEnabled = true;
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
+    
+    if (clozeOneByOneEnabled) {
+      document.getElementById("1by1-btns").style.display = "block";
+    }
+    })()
+  </script>
 
 {{#Lecture Notes}}
 <span id = "hint-ln" class="hintBtn" data-name="Lecture Notes">
@@ -298,11 +310,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <script>
   (function() {
     var clozeOneByOneEnabled = true;
-    try {
-        clozeOneByOneEnabled = `{{One by one}}` !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
 
     if (!clozeOneByOneEnabled) {
       return

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -34,13 +34,11 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
-  try {
-    clozeOneByOneEnabled = `{{One by one}}` !== ""
-  } catch (exception) {
-    console.log(exception)
-  }
+    clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
   
   window.clozeHints = [];
   if (clozeOneByOneEnabled) {

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -97,12 +97,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- BUTTON FIELDS -->
 <!-- ClOZE ONE BY ONE BUTTONS -->
-{{#One by one}}
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
-<br />
-{{/One by one}}
 
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
+<div id="1by1-btns" style="display: none;">
+  <button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+  <button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+</div>
+
+<script>
+  (() => {
+    let clozeOneByOneEnabled = true;
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
+    
+    if (clozeOneByOneEnabled) {
+      document.getElementById("1by1-btns").style.display = "block";
+    }
+    })()
+  </script>
 
 <!-- OME AUTO OPEN FIELD -->
 <div class="banner-ome">{{#OME}}{{OME}}{{/OME}}</div>
@@ -415,11 +427,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <script>
   (function() {
     var clozeOneByOneEnabled = true;
-    try {
-        clozeOneByOneEnabled = `{{One by one}}` !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
 
     if (!clozeOneByOneEnabled) {
       return

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -34,13 +34,11 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
-  try {
-    clozeOneByOneEnabled = `{{One by one}}` !== ""
-  } catch (exception) {
-    console.log(exception)
-  }
+    clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
   
   window.clozeHints = [];
   if (clozeOneByOneEnabled) {

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.
@@ -19,6 +19,8 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
   

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -72,12 +72,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- BUTTON FIELDS -->
 <!-- ClOZE ONE BY ONE BUTTONS -->
-{{#One by one}}
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
-<br />
-{{/One by one}}
 
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
+<div id="1by1-btns" style="display: none;">
+  <button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+  <button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+</div>
+
+<script>
+  (() => {
+    let clozeOneByOneEnabled = true;
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
+    
+    if (clozeOneByOneEnabled) {
+      document.getElementById("1by1-btns").style.display = "block";
+    }
+    })()
+  </script>
 
 {{#Personal Notes}}
 <span id = "hint-ln" class="hintBtn" data-name="Personal Notes">
@@ -266,11 +278,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 <script>
   (function() {
     var clozeOneByOneEnabled = true;
-    try {
-        clozeOneByOneEnabled = `{{One by one}}` !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
 
     if (!clozeOneByOneEnabled) {
       return

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -33,13 +33,11 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
-  try {
-    clozeOneByOneEnabled = `{{One by one}}` !== ""
-  } catch (exception) {
-    console.log(exception)
-  }
+    clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
   
   window.clozeHints = [];
   if (clozeOneByOneEnabled) {

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 7f9b2fe -->
+<!-- version 95cfb16 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.
@@ -19,6 +19,8 @@ var numTagLevelsToShow = 0;
 
 
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
   

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 95cfb16 -->
+<!-- version 088a898 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/src/components/clozeOneByOne.ejs
+++ b/src/components/clozeOneByOne.ejs
@@ -34,11 +34,7 @@ _%>
   (function() {
     var clozeOneByOneEnabled = true;
     <%_ if (optional === true) { _%>
-    try {
-        clozeOneByOneEnabled = `{{One by one}}` !== ""
-    } catch (exception) {
-      console.log(exception)
-    }
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
     <%_ } _%>
 
     if (!clozeOneByOneEnabled) {

--- a/src/components/clozeOneByOneButtons.ejs
+++ b/src/components/clozeOneByOneButtons.ejs
@@ -6,12 +6,23 @@ Parameters:
 
 _%> 
 <!-- ClOZE ONE BY ONE BUTTONS -->
-<%_ if(optional) { _%>
-{{#One by one}}
-<%_ } _%>
-<button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
-<button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
-<br />
-<%_ if(optional) { _%>
-{{/One by one}}
-<%_ } _%>
+
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
+<div id="1by1-btns" style="display: none;">
+  <button id="button-reveal-next" class="button-general" onclick="revealNextCloze()">Reveal Next</button>
+  <button id="button-toggle-all" class="button-general" onclick="toggleAllCloze()">Toggle All</button>
+</div>
+
+<script>
+  (() => {
+    let clozeOneByOneEnabled = true;
+    <%_ if (optional === true) { _%>
+      clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
+    <%_ } _%>
+    
+    if (clozeOneByOneEnabled) {
+      document.getElementById("1by1-btns").style.display = "block";
+    }
+    })()
+  </script>

--- a/src/components/clozeOneByOneFront.ejs
+++ b/src/components/clozeOneByOneFront.ejs
@@ -15,14 +15,12 @@ if false, always one by one mode
 
 _%>
 <!-- CLOZE ONE BY ONE AUTOFLIP -->
+<div id="one-by-one" style="display: none;">{{One by one}}</div>
+
 <script>
   var clozeOneByOneEnabled = true;
   <%_ if (optional === true) { _%>
-  try {
-    clozeOneByOneEnabled = `{{One by one}}` !== ""
-  } catch (exception) {
-    console.log(exception)
-  }
+    clozeOneByOneEnabled = document.getElementById("one-by-one").textContent !== "";
   <%_ } _%>
   
   window.clozeHints = [];


### PR DESCRIPTION
Fixes #66

The detection of whether the field is empty fails if some other add-on adds `<script>` into the `{{One by one}}`, but atleast the full html isn't displayed.

This PR uses `div.innerText !== ""` instead of `{{#One by one}}{{/One by one}}` for empty field detection because Edit field during review cloze add-on transforms editable empty field into `<div data-EFDRCfield='..'></div>`, which fails `{{#One by one}}`