### PR TITLE
Fix conflict with ReColor: make io image not brighten on hover

### DIFF
--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Styling.css
+++ b/Note Types/IO-one by one/Styling.css
@@ -494,4 +494,5 @@ html:not(.mobile) #button-mq:hover{
 	font: inherit !important;
 	cursor: inherit !important;
 	outline: inherit !important;
+  filter: none !important;
 }

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version ce3c512 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Styling.css
+++ b/Note Types/Physeo-IO one by one/Styling.css
@@ -494,4 +494,5 @@ html:not(.mobile) #button-mq:hover {
 	font: inherit !important;
 	cursor: inherit !important;
 	outline: inherit !important;
+  filter: none !important;
 }

--- a/src/notetypes/IO-one by one/Styling.css
+++ b/src/notetypes/IO-one by one/Styling.css
@@ -494,4 +494,5 @@ html:not(.mobile) #button-mq:hover{
 	font: inherit !important;
 	cursor: inherit !important;
 	outline: inherit !important;
+  filter: none !important;
 }

--- a/src/notetypes/Physeo-IO one by one/Styling.css
+++ b/src/notetypes/Physeo-IO one by one/Styling.css
@@ -494,4 +494,5 @@ html:not(.mobile) #button-mq:hover {
 	font: inherit !important;
 	cursor: inherit !important;
 	outline: inherit !important;
+  filter: none !important;
 }


### PR DESCRIPTION
This fixes the IO image brightening when hovered over.

The better solution would have been to change `<button class="dummy-btn">` to a `<div>`, but in case there was a reason the image was a `<button>`, I just changed the styling to override the css injected by ReColor add-on.
