### PR TITLE
Fix Cloze one by one

### DIFF
--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -272,10 +272,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze[data-content]:hover {
+  .cloze-replacer:hover {
     cursor: pointer;
   }
-  .cloze[data-hint] {
+  .cloze-hidden {
+    display: none;
+  }
+  .cloze-hint {
     color: #009400 !important;
   }
 </style>
@@ -288,99 +291,104 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     if (!clozeOneByOneEnabled) {
       return
     }
-    
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      rerunMathJax()
-
-      delete elem.dataset.content
-      delete elem.dataset.hint
-    }
-
-    const revealClozeWord = function(elem) {
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-          delete elem.dataset.hint
-        }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
-      }
-      rerunMathJax()
-    }
-
-    window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
-      if(!nextHidden) {
-          return
-      } 
-      if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
-      } else {
-          revealCloze(nextHidden)
-      }
-    }
 
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
+      for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
         if (cloze.offsetWidth === 0) {
           continue
         }
-        cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[count]) {
-          cloze.innerHTML = window.clozeHints[count]
-          cloze.dataset.hint = true
-        } else {
-          cloze.innerHTML = clozeHider(cloze)
+        const clozeReplacer = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeReplacer.classList.add("cloze-replacer")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeReplacer.innerHTML = clozeHider(cloze)
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
+        }
+        cloze.appendChild(clozeReplacer)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
         }
         count += 1
-        if (initial === true) {
+        if (initial) {
           cloze.addEventListener("touchend", revealClozeClicked)
           cloze.addEventListener("click", revealClozeClicked)
         }
       }
     }
+    
+    const revealCloze = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
 
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
-      if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
-        }
+      cloze.removeChild(clozeReplacer)
+      cloze.removeChild(clozeHidden)
+      while (clozeHidden.childNodes.length > 0) {
+        cloze.appendChild(clozeHidden.childNodes[0])
+      }
+    }
+
+    const revealClozeWord = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
+
+      let range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundSpace = setRangeEnd(range, clozeHidden, "beforeFirstSpace")
+      if (!foundSpace) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }
+      let fragment = range.extractContents()
+      cloze.insertBefore(fragment, clozeReplacer)
+      // Extract whitespaces after word
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundWord = setRangeEnd(range, clozeHidden, "afterLastSpace")
+      if (!foundWord) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }    
+      fragment = range.extractContents();
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (!foundWord) {
+        cloze.removeChild(clozeHidden)
+        cloze.removeChild(clozeReplacer)
+        return
+      }
+'1 '
+      clozeReplacer.innerHTML = clozeHider(clozeHidden)
+      if (clozeReplacer.classList.contains("cloze-hint")) [
+        clozeReplacer.classList.remove("cloze-hint")
+      ]
+    }
+
+    const revealNextClozeOf = (type) => {
+      const nextHidden = document.querySelector(".cloze-hidden")
+      if(!nextHidden) {
+          return
+      } 
+      const cloze = clozeElOfClozeHidden(nextHidden);
+      if (type === "word") {
+          revealClozeWord(cloze)
+      } else if (type === "cloze") {
+          revealCloze(cloze)
       } else {
-        hideAllCloze(initial=false)
+        console.error("Invalid type: " + type)
       }
     }
 
     const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
       if (!ev.altKey && (revealNextClozeMode !== "word")) {
         revealCloze(elem)
       } else {
@@ -388,20 +396,60 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
       ev.stopPropagation()
       ev.preventDefault()
-    }      
-
-    const rerunMathJax = function() {
-      // rerun mathjax on the document so that the cloze text gets formatted
-      // ... for MathJax 2
-      try {
-          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-      } catch {}
-      // ... for MathJax 3     
-      try {
-          MathJax.typesetPromise()
-      } catch {}
     }
-    
+
+    window.revealNextCloze = function() {
+      revealNextClozeOf(revealNextClozeMode)
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze-hidden")
+      if(elems.length > 0) {
+        for (const elem of elems) {
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
+    }
+
+    /**
+     * mode: 'beforeFirstSpace' or 'afterLastSpace'
+     * Return `true` if it exists and setEnd() was called, otherwise `false`
+     */
+    const setRangeEnd = function(range, node, mode) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const match = node.textContent.match(regex)
+        if (match) {
+          range.setEnd(node, match.index);
+          return true;
+        } else {
+          return false;
+        }
+      } else if (!ignoreSpaceInNode(node)) {
+        for (const child of node.childNodes) {
+          if (setRangeEnd(range, child, mode)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    const ignoreSpaceInNode = function (node) {
+      return node.tagName === "MJX-ASSISTIVE-MML"
+    }
+
+
     hideAllCloze(initial=true)
 
     let isShowNextShortcut = shortcutMatcher(window.revealNextShortcut)
@@ -411,22 +459,17 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       let next = isShowNextShortcut(ev)
       let word = isShowWordShortcut(ev)
       let all = isToggleAllShortcut(ev)
-      if (next || word) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          if (next) {
-            revealCloze(elem)
-          } else {
-            revealClozeWord(elem)
-          }
-          ev.stopPropagation()
-          ev.preventDefault()
-        }
+      if (next) {
+        revealNextClozeOf("cloze")
+      } else if (word) {
+        revealNextClozeOf("word")
       } else if (all) {
         toggleAllCloze()
-        ev.stopPropagation()
-        ev.preventDefault()
+      } else {
+        return;
       }
+      ev.stopPropagation()
+      ev.preventDefault()
     });
   })()
 </script>

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -426,14 +426,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
      */
     const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
-          range.setEnd(node, match.index);
+          if (match.index === 0) {
+            while (node.previousSibling === null) {
+              node = node.parentElement
+            }
+            range.setEndBefore(node)
+          } else {
+            range.setEnd(node, match.index);
+          }
           return true;
         } else {
           return false;
         }
+      } else if (mode === 'afterLastSpace' && isWordNode(node)) {
+        range.setEndBefore(node)
+        return true
       } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
@@ -448,6 +458,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
+    const isWordNode = function(node) {
+      return ["IMG", "MJX-CONTAINER"].includes(node.tagName)
+    }
 
     hideAllCloze(initial=true)
 

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -365,7 +365,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         cloze.removeChild(clozeReplacer)
         return
       }
-'1 '
       clozeReplacer.innerHTML = clozeHider(clozeHidden)
       if (clozeReplacer.classList.contains("cloze-hint")) [
         clozeReplacer.classList.remove("cloze-hint")

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -457,14 +457,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
      */
     const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
-          range.setEnd(node, match.index);
+          if (match.index === 0) {
+            while (node.previousSibling === null) {
+              node = node.parentElement
+            }
+            range.setEndBefore(node)
+          } else {
+            range.setEnd(node, match.index);
+          }
           return true;
         } else {
           return false;
         }
+      } else if (mode === 'afterLastSpace' && isWordNode(node)) {
+        range.setEndBefore(node)
+        return true
       } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
@@ -479,6 +489,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
+    const isWordNode = function(node) {
+      return ["IMG", "MJX-CONTAINER"].includes(node.tagName)
+    }
 
     hideAllCloze(initial=true)
 

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -396,7 +396,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         cloze.removeChild(clozeReplacer)
         return
       }
-'1 '
       clozeReplacer.innerHTML = clozeHider(clozeHidden)
       if (clozeReplacer.classList.contains("cloze-hint")) [
         clozeReplacer.classList.remove("cloze-hint")

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -303,10 +303,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze[data-content]:hover {
+  .cloze-replacer:hover {
     cursor: pointer;
   }
-  .cloze[data-hint] {
+  .cloze-hidden {
+    display: none;
+  }
+  .cloze-hint {
     color: #009400 !important;
   }
 </style>
@@ -319,99 +322,104 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     if (!clozeOneByOneEnabled) {
       return
     }
-    
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      rerunMathJax()
-
-      delete elem.dataset.content
-      delete elem.dataset.hint
-    }
-
-    const revealClozeWord = function(elem) {
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-          delete elem.dataset.hint
-        }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
-      }
-      rerunMathJax()
-    }
-
-    window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
-      if(!nextHidden) {
-          return
-      } 
-      if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
-      } else {
-          revealCloze(nextHidden)
-      }
-    }
 
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
+      for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
         if (cloze.offsetWidth === 0) {
           continue
         }
-        cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[count]) {
-          cloze.innerHTML = window.clozeHints[count]
-          cloze.dataset.hint = true
-        } else {
-          cloze.innerHTML = clozeHider(cloze)
+        const clozeReplacer = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeReplacer.classList.add("cloze-replacer")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeReplacer.innerHTML = clozeHider(cloze)
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
+        }
+        cloze.appendChild(clozeReplacer)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
         }
         count += 1
-        if (initial === true) {
+        if (initial) {
           cloze.addEventListener("touchend", revealClozeClicked)
           cloze.addEventListener("click", revealClozeClicked)
         }
       }
     }
+    
+    const revealCloze = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
 
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
-      if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
-        }
+      cloze.removeChild(clozeReplacer)
+      cloze.removeChild(clozeHidden)
+      while (clozeHidden.childNodes.length > 0) {
+        cloze.appendChild(clozeHidden.childNodes[0])
+      }
+    }
+
+    const revealClozeWord = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
+
+      let range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundSpace = setRangeEnd(range, clozeHidden, "beforeFirstSpace")
+      if (!foundSpace) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }
+      let fragment = range.extractContents()
+      cloze.insertBefore(fragment, clozeReplacer)
+      // Extract whitespaces after word
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundWord = setRangeEnd(range, clozeHidden, "afterLastSpace")
+      if (!foundWord) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }    
+      fragment = range.extractContents();
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (!foundWord) {
+        cloze.removeChild(clozeHidden)
+        cloze.removeChild(clozeReplacer)
+        return
+      }
+'1 '
+      clozeReplacer.innerHTML = clozeHider(clozeHidden)
+      if (clozeReplacer.classList.contains("cloze-hint")) [
+        clozeReplacer.classList.remove("cloze-hint")
+      ]
+    }
+
+    const revealNextClozeOf = (type) => {
+      const nextHidden = document.querySelector(".cloze-hidden")
+      if(!nextHidden) {
+          return
+      } 
+      const cloze = clozeElOfClozeHidden(nextHidden);
+      if (type === "word") {
+          revealClozeWord(cloze)
+      } else if (type === "cloze") {
+          revealCloze(cloze)
       } else {
-        hideAllCloze(initial=false)
+        console.error("Invalid type: " + type)
       }
     }
 
     const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
       if (!ev.altKey && (revealNextClozeMode !== "word")) {
         revealCloze(elem)
       } else {
@@ -419,20 +427,60 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
       ev.stopPropagation()
       ev.preventDefault()
-    }      
-
-    const rerunMathJax = function() {
-      // rerun mathjax on the document so that the cloze text gets formatted
-      // ... for MathJax 2
-      try {
-          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-      } catch {}
-      // ... for MathJax 3     
-      try {
-          MathJax.typesetPromise()
-      } catch {}
     }
-    
+
+    window.revealNextCloze = function() {
+      revealNextClozeOf(revealNextClozeMode)
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze-hidden")
+      if(elems.length > 0) {
+        for (const elem of elems) {
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
+    }
+
+    /**
+     * mode: 'beforeFirstSpace' or 'afterLastSpace'
+     * Return `true` if it exists and setEnd() was called, otherwise `false`
+     */
+    const setRangeEnd = function(range, node, mode) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const match = node.textContent.match(regex)
+        if (match) {
+          range.setEnd(node, match.index);
+          return true;
+        } else {
+          return false;
+        }
+      } else if (!ignoreSpaceInNode(node)) {
+        for (const child of node.childNodes) {
+          if (setRangeEnd(range, child, mode)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    const ignoreSpaceInNode = function (node) {
+      return node.tagName === "MJX-ASSISTIVE-MML"
+    }
+
+
     hideAllCloze(initial=true)
 
     let isShowNextShortcut = shortcutMatcher(window.revealNextShortcut)
@@ -442,22 +490,17 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       let next = isShowNextShortcut(ev)
       let word = isShowWordShortcut(ev)
       let all = isToggleAllShortcut(ev)
-      if (next || word) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          if (next) {
-            revealCloze(elem)
-          } else {
-            revealClozeWord(elem)
-          }
-          ev.stopPropagation()
-          ev.preventDefault()
-        }
+      if (next) {
+        revealNextClozeOf("cloze")
+      } else if (word) {
+        revealNextClozeOf("word")
       } else if (all) {
         toggleAllCloze()
-        ev.stopPropagation()
-        ev.preventDefault()
+      } else {
+        return;
       }
+      ev.stopPropagation()
+      ev.preventDefault()
     });
   })()
 </script>

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -305,10 +305,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze[data-content]:hover {
+  .cloze-replacer:hover {
     cursor: pointer;
   }
-  .cloze[data-hint] {
+  .cloze-hidden {
+    display: none;
+  }
+  .cloze-hint {
     color: #009400 !important;
   }
 </style>
@@ -321,99 +324,104 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     if (!clozeOneByOneEnabled) {
       return
     }
-    
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      rerunMathJax()
-
-      delete elem.dataset.content
-      delete elem.dataset.hint
-    }
-
-    const revealClozeWord = function(elem) {
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-          delete elem.dataset.hint
-        }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
-      }
-      rerunMathJax()
-    }
-
-    window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
-      if(!nextHidden) {
-          return
-      } 
-      if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
-      } else {
-          revealCloze(nextHidden)
-      }
-    }
 
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
+      for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
         if (cloze.offsetWidth === 0) {
           continue
         }
-        cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[count]) {
-          cloze.innerHTML = window.clozeHints[count]
-          cloze.dataset.hint = true
-        } else {
-          cloze.innerHTML = clozeHider(cloze)
+        const clozeReplacer = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeReplacer.classList.add("cloze-replacer")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeReplacer.innerHTML = clozeHider(cloze)
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
+        }
+        cloze.appendChild(clozeReplacer)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
         }
         count += 1
-        if (initial === true) {
+        if (initial) {
           cloze.addEventListener("touchend", revealClozeClicked)
           cloze.addEventListener("click", revealClozeClicked)
         }
       }
     }
+    
+    const revealCloze = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
 
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
-      if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
-        }
+      cloze.removeChild(clozeReplacer)
+      cloze.removeChild(clozeHidden)
+      while (clozeHidden.childNodes.length > 0) {
+        cloze.appendChild(clozeHidden.childNodes[0])
+      }
+    }
+
+    const revealClozeWord = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
+
+      let range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundSpace = setRangeEnd(range, clozeHidden, "beforeFirstSpace")
+      if (!foundSpace) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }
+      let fragment = range.extractContents()
+      cloze.insertBefore(fragment, clozeReplacer)
+      // Extract whitespaces after word
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundWord = setRangeEnd(range, clozeHidden, "afterLastSpace")
+      if (!foundWord) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }    
+      fragment = range.extractContents();
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (!foundWord) {
+        cloze.removeChild(clozeHidden)
+        cloze.removeChild(clozeReplacer)
+        return
+      }
+'1 '
+      clozeReplacer.innerHTML = clozeHider(clozeHidden)
+      if (clozeReplacer.classList.contains("cloze-hint")) [
+        clozeReplacer.classList.remove("cloze-hint")
+      ]
+    }
+
+    const revealNextClozeOf = (type) => {
+      const nextHidden = document.querySelector(".cloze-hidden")
+      if(!nextHidden) {
+          return
+      } 
+      const cloze = clozeElOfClozeHidden(nextHidden);
+      if (type === "word") {
+          revealClozeWord(cloze)
+      } else if (type === "cloze") {
+          revealCloze(cloze)
       } else {
-        hideAllCloze(initial=false)
+        console.error("Invalid type: " + type)
       }
     }
 
     const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
       if (!ev.altKey && (revealNextClozeMode !== "word")) {
         revealCloze(elem)
       } else {
@@ -421,20 +429,60 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
       ev.stopPropagation()
       ev.preventDefault()
-    }      
-
-    const rerunMathJax = function() {
-      // rerun mathjax on the document so that the cloze text gets formatted
-      // ... for MathJax 2
-      try {
-          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-      } catch {}
-      // ... for MathJax 3     
-      try {
-          MathJax.typesetPromise()
-      } catch {}
     }
-    
+
+    window.revealNextCloze = function() {
+      revealNextClozeOf(revealNextClozeMode)
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze-hidden")
+      if(elems.length > 0) {
+        for (const elem of elems) {
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
+    }
+
+    /**
+     * mode: 'beforeFirstSpace' or 'afterLastSpace'
+     * Return `true` if it exists and setEnd() was called, otherwise `false`
+     */
+    const setRangeEnd = function(range, node, mode) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const match = node.textContent.match(regex)
+        if (match) {
+          range.setEnd(node, match.index);
+          return true;
+        } else {
+          return false;
+        }
+      } else if (!ignoreSpaceInNode(node)) {
+        for (const child of node.childNodes) {
+          if (setRangeEnd(range, child, mode)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    const ignoreSpaceInNode = function (node) {
+      return node.tagName === "MJX-ASSISTIVE-MML"
+    }
+
+
     hideAllCloze(initial=true)
 
     let isShowNextShortcut = shortcutMatcher(window.revealNextShortcut)
@@ -444,22 +492,17 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       let next = isShowNextShortcut(ev)
       let word = isShowWordShortcut(ev)
       let all = isToggleAllShortcut(ev)
-      if (next || word) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          if (next) {
-            revealCloze(elem)
-          } else {
-            revealClozeWord(elem)
-          }
-          ev.stopPropagation()
-          ev.preventDefault()
-        }
+      if (next) {
+        revealNextClozeOf("cloze")
+      } else if (word) {
+        revealNextClozeOf("word")
       } else if (all) {
         toggleAllCloze()
-        ev.stopPropagation()
-        ev.preventDefault()
+      } else {
+        return;
       }
+      ev.stopPropagation()
+      ev.preventDefault()
     });
   })()
 </script>

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -398,7 +398,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         cloze.removeChild(clozeReplacer)
         return
       }
-'1 '
       clozeReplacer.innerHTML = clozeHider(clozeHidden)
       if (clozeReplacer.classList.contains("cloze-hint")) [
         clozeReplacer.classList.remove("cloze-hint")

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -459,14 +459,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
      */
     const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
-          range.setEnd(node, match.index);
+          if (match.index === 0) {
+            while (node.previousSibling === null) {
+              node = node.parentElement
+            }
+            range.setEndBefore(node)
+          } else {
+            range.setEnd(node, match.index);
+          }
           return true;
         } else {
           return false;
         }
+      } else if (mode === 'afterLastSpace' && isWordNode(node)) {
+        range.setEndBefore(node)
+        return true
       } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
@@ -481,6 +491,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
+    const isWordNode = function(node) {
+      return ["IMG", "MJX-CONTAINER"].includes(node.tagName)
+    }
 
     hideAllCloze(initial=true)
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -515,7 +515,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         cloze.removeChild(clozeReplacer)
         return
       }
-'1 '
       clozeReplacer.innerHTML = clozeHider(clozeHidden)
       if (clozeReplacer.classList.contains("cloze-hint")) [
         clozeReplacer.classList.remove("cloze-hint")

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -422,10 +422,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze[data-content]:hover {
+  .cloze-replacer:hover {
     cursor: pointer;
   }
-  .cloze[data-hint] {
+  .cloze-hidden {
+    display: none;
+  }
+  .cloze-hint {
     color: #009400 !important;
   }
 </style>
@@ -438,99 +441,104 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     if (!clozeOneByOneEnabled) {
       return
     }
-    
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      rerunMathJax()
-
-      delete elem.dataset.content
-      delete elem.dataset.hint
-    }
-
-    const revealClozeWord = function(elem) {
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-          delete elem.dataset.hint
-        }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
-      }
-      rerunMathJax()
-    }
-
-    window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
-      if(!nextHidden) {
-          return
-      } 
-      if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
-      } else {
-          revealCloze(nextHidden)
-      }
-    }
 
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
+      for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
         if (cloze.offsetWidth === 0) {
           continue
         }
-        cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[count]) {
-          cloze.innerHTML = window.clozeHints[count]
-          cloze.dataset.hint = true
-        } else {
-          cloze.innerHTML = clozeHider(cloze)
+        const clozeReplacer = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeReplacer.classList.add("cloze-replacer")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeReplacer.innerHTML = clozeHider(cloze)
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
+        }
+        cloze.appendChild(clozeReplacer)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
         }
         count += 1
-        if (initial === true) {
+        if (initial) {
           cloze.addEventListener("touchend", revealClozeClicked)
           cloze.addEventListener("click", revealClozeClicked)
         }
       }
     }
+    
+    const revealCloze = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
 
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
-      if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
-        }
+      cloze.removeChild(clozeReplacer)
+      cloze.removeChild(clozeHidden)
+      while (clozeHidden.childNodes.length > 0) {
+        cloze.appendChild(clozeHidden.childNodes[0])
+      }
+    }
+
+    const revealClozeWord = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
+
+      let range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundSpace = setRangeEnd(range, clozeHidden, "beforeFirstSpace")
+      if (!foundSpace) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }
+      let fragment = range.extractContents()
+      cloze.insertBefore(fragment, clozeReplacer)
+      // Extract whitespaces after word
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundWord = setRangeEnd(range, clozeHidden, "afterLastSpace")
+      if (!foundWord) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }    
+      fragment = range.extractContents();
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (!foundWord) {
+        cloze.removeChild(clozeHidden)
+        cloze.removeChild(clozeReplacer)
+        return
+      }
+'1 '
+      clozeReplacer.innerHTML = clozeHider(clozeHidden)
+      if (clozeReplacer.classList.contains("cloze-hint")) [
+        clozeReplacer.classList.remove("cloze-hint")
+      ]
+    }
+
+    const revealNextClozeOf = (type) => {
+      const nextHidden = document.querySelector(".cloze-hidden")
+      if(!nextHidden) {
+          return
+      } 
+      const cloze = clozeElOfClozeHidden(nextHidden);
+      if (type === "word") {
+          revealClozeWord(cloze)
+      } else if (type === "cloze") {
+          revealCloze(cloze)
       } else {
-        hideAllCloze(initial=false)
+        console.error("Invalid type: " + type)
       }
     }
 
     const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
       if (!ev.altKey && (revealNextClozeMode !== "word")) {
         revealCloze(elem)
       } else {
@@ -538,20 +546,60 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
       ev.stopPropagation()
       ev.preventDefault()
-    }      
-
-    const rerunMathJax = function() {
-      // rerun mathjax on the document so that the cloze text gets formatted
-      // ... for MathJax 2
-      try {
-          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-      } catch {}
-      // ... for MathJax 3     
-      try {
-          MathJax.typesetPromise()
-      } catch {}
     }
-    
+
+    window.revealNextCloze = function() {
+      revealNextClozeOf(revealNextClozeMode)
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze-hidden")
+      if(elems.length > 0) {
+        for (const elem of elems) {
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
+    }
+
+    /**
+     * mode: 'beforeFirstSpace' or 'afterLastSpace'
+     * Return `true` if it exists and setEnd() was called, otherwise `false`
+     */
+    const setRangeEnd = function(range, node, mode) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const match = node.textContent.match(regex)
+        if (match) {
+          range.setEnd(node, match.index);
+          return true;
+        } else {
+          return false;
+        }
+      } else if (!ignoreSpaceInNode(node)) {
+        for (const child of node.childNodes) {
+          if (setRangeEnd(range, child, mode)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    const ignoreSpaceInNode = function (node) {
+      return node.tagName === "MJX-ASSISTIVE-MML"
+    }
+
+
     hideAllCloze(initial=true)
 
     let isShowNextShortcut = shortcutMatcher(window.revealNextShortcut)
@@ -561,22 +609,17 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       let next = isShowNextShortcut(ev)
       let word = isShowWordShortcut(ev)
       let all = isToggleAllShortcut(ev)
-      if (next || word) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          if (next) {
-            revealCloze(elem)
-          } else {
-            revealClozeWord(elem)
-          }
-          ev.stopPropagation()
-          ev.preventDefault()
-        }
+      if (next) {
+        revealNextClozeOf("cloze")
+      } else if (word) {
+        revealNextClozeOf("word")
       } else if (all) {
         toggleAllCloze()
-        ev.stopPropagation()
-        ev.preventDefault()
+      } else {
+        return;
       }
+      ev.stopPropagation()
+      ev.preventDefault()
     });
   })()
 </script>

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -576,14 +576,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
      */
     const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
-          range.setEnd(node, match.index);
+          if (match.index === 0) {
+            while (node.previousSibling === null) {
+              node = node.parentElement
+            }
+            range.setEndBefore(node)
+          } else {
+            range.setEnd(node, match.index);
+          }
           return true;
         } else {
           return false;
         }
+      } else if (mode === 'afterLastSpace' && isWordNode(node)) {
+        range.setEndBefore(node)
+        return true
       } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
@@ -598,6 +608,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
+    const isWordNode = function(node) {
+      return ["IMG", "MJX-CONTAINER"].includes(node.tagName)
+    }
 
     hideAllCloze(initial=true)
 

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -366,7 +366,6 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         cloze.removeChild(clozeReplacer)
         return
       }
-'1 '
       clozeReplacer.innerHTML = clozeHider(clozeHidden)
       if (clozeReplacer.classList.contains("cloze-hint")) [
         clozeReplacer.classList.remove("cloze-hint")

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -273,10 +273,13 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze[data-content]:hover {
+  .cloze-replacer:hover {
     cursor: pointer;
   }
-  .cloze[data-hint] {
+  .cloze-hidden {
+    display: none;
+  }
+  .cloze-hint {
     color: #009400 !important;
   }
 </style>
@@ -289,99 +292,104 @@ replace the arrows/dashes from the statement below with double curly brackets-->
     if (!clozeOneByOneEnabled) {
       return
     }
-    
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      rerunMathJax()
-
-      delete elem.dataset.content
-      delete elem.dataset.hint
-    }
-
-    const revealClozeWord = function(elem) {
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-          delete elem.dataset.hint
-        }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
-      }
-      rerunMathJax()
-    }
-
-    window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
-      if(!nextHidden) {
-          return
-      } 
-      if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
-      } else {
-          revealCloze(nextHidden)
-      }
-    }
 
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
+      for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
         if (cloze.offsetWidth === 0) {
           continue
         }
-        cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[count]) {
-          cloze.innerHTML = window.clozeHints[count]
-          cloze.dataset.hint = true
-        } else {
-          cloze.innerHTML = clozeHider(cloze)
+        const clozeReplacer = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeReplacer.classList.add("cloze-replacer")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeReplacer.innerHTML = clozeHider(cloze)
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
+        }
+        cloze.appendChild(clozeReplacer)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
         }
         count += 1
-        if (initial === true) {
+        if (initial) {
           cloze.addEventListener("touchend", revealClozeClicked)
           cloze.addEventListener("click", revealClozeClicked)
         }
       }
     }
+    
+    const revealCloze = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
 
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
-      if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
-        }
+      cloze.removeChild(clozeReplacer)
+      cloze.removeChild(clozeHidden)
+      while (clozeHidden.childNodes.length > 0) {
+        cloze.appendChild(clozeHidden.childNodes[0])
+      }
+    }
+
+    const revealClozeWord = function(cloze) {
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeReplacer || !clozeHidden) return;
+
+      let range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundSpace = setRangeEnd(range, clozeHidden, "beforeFirstSpace")
+      if (!foundSpace) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }
+      let fragment = range.extractContents()
+      cloze.insertBefore(fragment, clozeReplacer)
+      // Extract whitespaces after word
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundWord = setRangeEnd(range, clozeHidden, "afterLastSpace")
+      if (!foundWord) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }    
+      fragment = range.extractContents();
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (!foundWord) {
+        cloze.removeChild(clozeHidden)
+        cloze.removeChild(clozeReplacer)
+        return
+      }
+'1 '
+      clozeReplacer.innerHTML = clozeHider(clozeHidden)
+      if (clozeReplacer.classList.contains("cloze-hint")) [
+        clozeReplacer.classList.remove("cloze-hint")
+      ]
+    }
+
+    const revealNextClozeOf = (type) => {
+      const nextHidden = document.querySelector(".cloze-hidden")
+      if(!nextHidden) {
+          return
+      } 
+      const cloze = clozeElOfClozeHidden(nextHidden);
+      if (type === "word") {
+          revealClozeWord(cloze)
+      } else if (type === "cloze") {
+          revealCloze(cloze)
       } else {
-        hideAllCloze(initial=false)
+        console.error("Invalid type: " + type)
       }
     }
 
     const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
       if (!ev.altKey && (revealNextClozeMode !== "word")) {
         revealCloze(elem)
       } else {
@@ -389,20 +397,60 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       }
       ev.stopPropagation()
       ev.preventDefault()
-    }      
-
-    const rerunMathJax = function() {
-      // rerun mathjax on the document so that the cloze text gets formatted
-      // ... for MathJax 2
-      try {
-          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-      } catch {}
-      // ... for MathJax 3     
-      try {
-          MathJax.typesetPromise()
-      } catch {}
     }
-    
+
+    window.revealNextCloze = function() {
+      revealNextClozeOf(revealNextClozeMode)
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze-hidden")
+      if(elems.length > 0) {
+        for (const elem of elems) {
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
+    }
+
+    /**
+     * mode: 'beforeFirstSpace' or 'afterLastSpace'
+     * Return `true` if it exists and setEnd() was called, otherwise `false`
+     */
+    const setRangeEnd = function(range, node, mode) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const match = node.textContent.match(regex)
+        if (match) {
+          range.setEnd(node, match.index);
+          return true;
+        } else {
+          return false;
+        }
+      } else if (!ignoreSpaceInNode(node)) {
+        for (const child of node.childNodes) {
+          if (setRangeEnd(range, child, mode)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    const ignoreSpaceInNode = function (node) {
+      return node.tagName === "MJX-ASSISTIVE-MML"
+    }
+
+
     hideAllCloze(initial=true)
 
     let isShowNextShortcut = shortcutMatcher(window.revealNextShortcut)
@@ -412,22 +460,17 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       let next = isShowNextShortcut(ev)
       let word = isShowWordShortcut(ev)
       let all = isToggleAllShortcut(ev)
-      if (next || word) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          if (next) {
-            revealCloze(elem)
-          } else {
-            revealClozeWord(elem)
-          }
-          ev.stopPropagation()
-          ev.preventDefault()
-        }
+      if (next) {
+        revealNextClozeOf("cloze")
+      } else if (word) {
+        revealNextClozeOf("word")
       } else if (all) {
         toggleAllCloze()
-        ev.stopPropagation()
-        ev.preventDefault()
+      } else {
+        return;
       }
+      ev.stopPropagation()
+      ev.preventDefault()
     });
   })()
 </script>

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -427,14 +427,24 @@ replace the arrows/dashes from the statement below with double curly brackets-->
      */
     const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
-          range.setEnd(node, match.index);
+          if (match.index === 0) {
+            while (node.previousSibling === null) {
+              node = node.parentElement
+            }
+            range.setEndBefore(node)
+          } else {
+            range.setEnd(node, match.index);
+          }
           return true;
         } else {
           return false;
         }
+      } else if (mode === 'afterLastSpace' && isWordNode(node)) {
+        range.setEndBefore(node)
+        return true
       } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
@@ -449,6 +459,9 @@ replace the arrows/dashes from the statement below with double curly brackets-->
       return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
+    const isWordNode = function(node) {
+      return ["IMG", "MJX-CONTAINER"].includes(node.tagName)
+    }
 
     hideAllCloze(initial=true)
 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 522e04f -->
+<!-- version b3d04b0 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d7a010c -->
+<!-- version aada609 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 172a49a -->
+<!-- version d7a010c -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version aada609 -->
+<!-- version 522e04f -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version b3d04b0 -->
+<!-- version 6054e5f -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -24,10 +24,13 @@ _%>
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze[data-content]:hover {
+  .cloze-hider:hover {
     cursor: pointer;
   }
-  .cloze[data-hint] {
+  .cloze-hidden {
+    display: none;
+  }
+  .cloze-hint {
     color: #009400 !important;
   }
 </style>
@@ -43,75 +46,116 @@ _%>
       return
     }
     
-    const revealCloze = function(elem) {
-      // Checking for dataset.content is undefined may not be needed anymore?
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      elem.innerHTML = elem.dataset.content
-      rerunMathJax()
+    const revealCloze = function(cloze) {
+      const clozeHider = cloze.getElementsByClassName("cloze-hider")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeHider || !clozeHidden) return;
 
-      delete elem.dataset.content
-      delete elem.dataset.hint
+      cloze.removeChild(clozeHider)
+      cloze.removeChild(clozeHidden)
+      for(const child of clozeHidden) {
+        cloze.appendChild(child)
+      }
+      rerunMathJax() // Is this still needed?
     }
 
-    const revealClozeWord = function(elem) {
-      if (elem.dataset.content === undefined) {
-        return
-      }
-      if (elem.dataset.hidden !== undefined) {
-        let words = elem.dataset.hidden.split(" ");
-        if (words.length == 1) {
-          revealCloze(elem)
-          delete elem.dataset.hidden
-          delete elem.dataset.revealed
-        } else {
-          elem.dataset.revealed = elem.dataset.revealed + " " + words[0]
-          elem.dataset.hidden = words.slice(1).join(" ");
-          let temp = document.createElement("div");
-          temp.innerHTML = elem.dataset.hidden;
-          elem.innerHTML = elem.dataset.revealed + " " + clozeHider(temp);
-          delete elem.dataset.hint
+    const revealClozeWord = function(cloze) {
+      const clozeHider = cloze.getElementsByClassName("cloze-hider")[0]
+      const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+      if (!clozeHider || !clozeHidden) return;
+
+      const range = new Range()
+      range.setStart(clozeHidden, 0)
+      let enable = true
+      while(enable) {
+        const found = setRangeEndToFirstSpace(range, clozeHidden)
+        if (!found) {
+          range.setEnd(clozeHidden, clozeHidden.childNodes.length)
         }
-      } else {
-        let temp = document.createElement("div");
-        temp.innerHTML = elem.dataset.content;
-        elem.dataset.hidden = temp.textContent;
-        elem.dataset.revealed = "";
-        revealClozeWord(elem)
+        const onlyWhitespace = /^\s*$/.test(range.toString())
+        enable = found && onlyWhitespace
+
+        const fragment = range.extractContents()
+        cloze.insertBefore(fragment, clozeHider)
+        clozeHider.innerHTML = clozeHider(clozeHidden)
+        if (!found) {
+          cloze.removeChild(clozeHidden)
+          cloze.removeChild(clozeHider)
+        }
       }
       rerunMathJax()
     }
 
     window.revealNextCloze = function() {
-      let nextHidden = document.querySelector(".cloze[data-content]")
+      const nextHidden = document.querySelector(".cloze-hidden")
       if(!nextHidden) {
           return
       } 
+      let cloze = nextHidden;
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
       if (revealNextClozeMode === "word") {
-          revealClozeWord(nextHidden)
+          revealClozeWord(cloze)
       } else {
-          revealCloze(nextHidden)
+          revealCloze(cloze)
       }
     }
 
+    /**
+     * Call range.setEnd() to before first whitespace character in node.
+     * Return `true` whitespace exists and setEnd() was called, otherwise `false`
+     */
+    const setRangeEndToFirstSpace = function(range, node) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        let firstWhitespace = -1;
+        for (const whitespace of [" ", "\n", "\t"]) {
+          const index = text.indexOf(whitespace);
+          if (index !== -1 && (firstWhitespace === -1 || index < firstWhitespace)) {
+            firstWhitespace = index;
+          }
+        }
+        if (firstWhitespace !== -1) {
+          range.setEnd(node, firstWhitespace);
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        for (const child of node.children) {
+          if (setRangeEndToFirstSpace(range, child)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    // Hide cloze into .cloze-hidden, add cloze-hider
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
-      for (let i = 0; i < clozes.length; i++) {
-        let cloze = clozes[i]
+      for (const cloze of clozes) {
         if (cloze.offsetWidth === 0) {
           continue
         }
-        cloze.dataset.content = cloze.innerHTML
-        if(window.clozeHints && window.clozeHints[count]) {
-          cloze.innerHTML = window.clozeHints[count]
-          cloze.dataset.hint = true
-        } else {
-          cloze.innerHTML = clozeHider(cloze)
+        const clozeHider = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeHider.classList.add("cloze-hider")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeHider.innerHTML = clozeHider(cloze)
+        for(const child of cloze.childNodes) {
+          clozeHidden.appendChild(child);
+        }
+        cloze.appendChild(clozeHider)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeHider.classList.add("cloez-hider")
+          clozeHider.innerHTML = window.clozeHints[count]
         }
         count += 1
-        if (initial === true) {
+        if (initial) {
           cloze.addEventListener("touchend", revealClozeClicked)
           cloze.addEventListener("click", revealClozeClicked)
         }
@@ -119,11 +163,10 @@ _%>
     }
 
     window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze[data-content]")
-      let button = document.getElementById("button-toggle-all")
+      let elems = document.querySelectorAll(".cloze-hidden")
       if(elems.length > 0) {
-        for (let i = 0; i < elems.length; i++) {
-            revealCloze(elems[i])
+        for (const elem of elems) {
+          elem.classList.remove("hidden");
         }
       } else {
         hideAllCloze(initial=false)

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -19,12 +19,21 @@ components/shortcutMatcher
 - Removes `#qa` element `display` property.
 - Exposes `toggleAllCloze` and `revealNextCloze` function
 
+# How it works
+|                .cloze                   |
+| shown | .cloze-replacer | .cloze-hidden |
+
+When hideAllCloze() is called, all childNodes of .cloze is moved into .cloze-hidden, 
+and .cloze has two children: div.cloze-replacer that hides cloze with `clozeHider(div.cloze-hidden)`, 
+div.cloze-hidden with original cloze content that is hidden with display:none.
+
+When revealNextWord() is called, a word is selected from .cloze-hidden and is inserted before div.cloze-replacer
 _%>
 <%- include('src/components/autoflipBack.ejs') %>
 
 <!-- CLOZE ONE BY ONE SCRIPT -->
 <style>
-  .cloze-hider:hover {
+  .cloze-replacer:hover {
     cursor: pointer;
   }
   .cloze-hidden {
@@ -47,11 +56,11 @@ _%>
     }
     
     const revealCloze = function(cloze) {
-      const clozeHider = cloze.getElementsByClassName("cloze-hider")[0]
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
       const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
-      if (!clozeHider || !clozeHidden) return;
+      if (!clozeReplacer || !clozeHidden) return;
 
-      cloze.removeChild(clozeHider)
+      cloze.removeChild(clozeReplacer)
       cloze.removeChild(clozeHidden)
       for(const child of clozeHidden) {
         cloze.appendChild(child)
@@ -60,9 +69,9 @@ _%>
     }
 
     const revealClozeWord = function(cloze) {
-      const clozeHider = cloze.getElementsByClassName("cloze-hider")[0]
+      const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
       const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
-      if (!clozeHider || !clozeHidden) return;
+      if (!clozeReplacer || !clozeHidden) return;
 
       const range = new Range()
       range.setStart(clozeHidden, 0)
@@ -76,11 +85,11 @@ _%>
         enable = found && onlyWhitespace
 
         const fragment = range.extractContents()
-        cloze.insertBefore(fragment, clozeHider)
-        clozeHider.innerHTML = clozeHider(clozeHidden)
+        cloze.insertBefore(fragment, clozeReplacer)
+        clozeReplacer.innerHTML = clozeHider(clozeHidden)
         if (!found) {
           cloze.removeChild(clozeHidden)
-          cloze.removeChild(clozeHider)
+          cloze.removeChild(clozeReplacer)
         }
       }
       rerunMathJax()
@@ -131,7 +140,6 @@ _%>
       }
     }
 
-    // Hide cloze into .cloze-hidden, add cloze-hider
     const hideAllCloze = function(initial) {
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
@@ -139,20 +147,20 @@ _%>
         if (cloze.offsetWidth === 0) {
           continue
         }
-        const clozeHider = document.createElement("span")
+        const clozeReplacer = document.createElement("span")
         const clozeHidden = document.createElement("span")
-        clozeHider.classList.add("cloze-hider")
+        clozeReplacer.classList.add("cloze-replacer")
         clozeHidden.classList.add("cloze-hidden")
-        clozeHider.innerHTML = clozeHider(cloze)
+        clozeReplacer.innerHTML = clozeHider(cloze)
         for(const child of cloze.childNodes) {
           clozeHidden.appendChild(child);
         }
-        cloze.appendChild(clozeHider)
+        cloze.appendChild(clozeReplacer)
         cloze.appendChild(clozeHidden)
 
         if (window.clozeHints && window.clozeHints[count]) {
-          clozeHider.classList.add("cloez-hider")
-          clozeHider.innerHTML = window.clozeHints[count]
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
         }
         count += 1
         if (initial) {

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -128,7 +128,6 @@ _%>
         cloze.removeChild(clozeReplacer)
         return
       }
-'1 '
       clozeReplacer.innerHTML = clozeHider(clozeHidden)
       if (clozeReplacer.classList.contains("cloze-hint")) [
         clozeReplacer.classList.remove("cloze-hint")

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -198,7 +198,7 @@ _%>
         } else {
           return false;
         }
-      } else {
+      } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
             return true;
@@ -206,6 +206,10 @@ _%>
         }
         return false;
       }
+    }
+
+    const ignoreSpaceInNode = function (node) {
+      return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
 

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -74,26 +74,31 @@ _%>
 
       let range = new Range()
       range.setStart(clozeHidden, 0)
-      const whitespaces = setRangeEndToAfterLastSpace(range, clozeHidden);
-      if (whitespaces) {
-        const fragment = range.extractContents();
-        cloze.insertBefore(fragment, clozeReplacer)
-      }
-
-      range = new Range()
-      range.setStart(clozeHidden, 0)
-      const found = setRangeEndToBeforeFirstSpace(range, clozeHidden)
-      if (!found) {
+      const foundSpace = setRangeEndToBeforeFirstSpace(range, clozeHidden)
+      if (!foundSpace) {
         range.setEnd(clozeHidden, clozeHidden.childNodes.length)
       }
-      const fragment = range.extractContents()
+      let fragment = range.extractContents()
       cloze.insertBefore(fragment, clozeReplacer)
-      if (found) {
-        clozeReplacer.innerHTML = clozeHider(clozeHidden)
-      } else {
+      // Extract whitespaces after word
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const foundWord = setRangeEndToAfterLastSpace(range, clozeHidden);
+      if (!foundWord) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }    
+      fragment = range.extractContents();
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (!foundWord) {
         cloze.removeChild(clozeHidden)
         cloze.removeChild(clozeReplacer)
+        return
       }
+'1 '
+      clozeReplacer.innerHTML = clozeHider(clozeHidden)
+      if (clozeReplacer.classList.contains("cloze-hint")) [
+        clozeReplacer.classList.remove("cloze-hint")
+      ]
     }
 
     const clozeElOfClozeHidden = (cloze) => {

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -192,7 +192,14 @@ _%>
         const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
-          range.setEnd(node, match.index);
+          if (match.index === 0) {
+            while (node.previousSibling === null) {
+              node = node.parentElement
+            }
+            range.setEndBefore(node)
+          } else {
+            range.setEnd(node, match.index);
+          }
           return true;
         } else {
           return false;

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -65,7 +65,6 @@ _%>
       while (clozeHidden.childNodes.length > 0) {
         cloze.appendChild(clozeHidden.childNodes[0])
       }
-      rerunMathJax() // Is this still needed?
     }
 
     const revealClozeWord = function(cloze) {
@@ -95,7 +94,6 @@ _%>
         cloze.removeChild(clozeHidden)
         cloze.removeChild(clozeReplacer)
       }
-      rerunMathJax()
     }
 
     const clozeElOfClozeHidden = (cloze) => {
@@ -222,18 +220,6 @@ _%>
       ev.preventDefault()
     }      
 
-    const rerunMathJax = function() {
-      // rerun mathjax on the document so that the cloze text gets formatted
-      // ... for MathJax 2
-      try {
-          MathJax.Hub.Queue(["Typeset", MathJax.Hub]);
-      } catch {}
-      // ... for MathJax 3     
-      try {
-          MathJax.typesetPromise()
-      } catch {}
-    }
-    
     hideAllCloze(initial=true)
 
     let isShowNextShortcut = shortcutMatcher(window.revealNextShortcut)

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -169,6 +169,10 @@ _%>
       let clozes = document.getElementsByClassName("cloze")
       let count = 0 // hidden cloze count
       for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
         if (cloze.offsetWidth === 0) {
           continue
         }

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -54,6 +54,40 @@ _%>
     if (!clozeOneByOneEnabled) {
       return
     }
+
+    const hideAllCloze = function(initial) {
+      let clozes = document.getElementsByClassName("cloze")
+      let count = 0 // hidden cloze count
+      for (const cloze of clozes) {
+        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
+        if (existingHidden) {
+          revealCloze(cloze);
+        }
+        if (cloze.offsetWidth === 0) {
+          continue
+        }
+        const clozeReplacer = document.createElement("span")
+        const clozeHidden = document.createElement("span")
+        clozeReplacer.classList.add("cloze-replacer")
+        clozeHidden.classList.add("cloze-hidden")
+        clozeReplacer.innerHTML = clozeHider(cloze)
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
+        }
+        cloze.appendChild(clozeReplacer)
+        cloze.appendChild(clozeHidden)
+
+        if (window.clozeHints && window.clozeHints[count]) {
+          clozeReplacer.classList.add("cloze-hint")
+          clozeReplacer.innerHTML = window.clozeHints[count]
+        }
+        count += 1
+        if (initial) {
+          cloze.addEventListener("touchend", revealClozeClicked)
+          cloze.addEventListener("click", revealClozeClicked)
+        }
+      }
+    }
     
     const revealCloze = function(cloze) {
       const clozeReplacer = cloze.getElementsByClassName("cloze-replacer")[0]
@@ -101,13 +135,6 @@ _%>
       ]
     }
 
-    const clozeElOfClozeHidden = (cloze) => {
-      while (!cloze.classList.contains("cloze")) {
-        cloze = cloze.parentElement;
-      }
-      return cloze;
-    }
-
     const revealNextClozeOf = (type) => {
       const nextHidden = document.querySelector(".cloze-hidden")
       if(!nextHidden) {
@@ -123,8 +150,38 @@ _%>
       }
     }
 
+    const revealClozeClicked = function(ev) {
+      let elem = ev.currentTarget
+      if (!ev.altKey && (revealNextClozeMode !== "word")) {
+        revealCloze(elem)
+      } else {
+        revealClozeWord(elem)
+      }
+      ev.stopPropagation()
+      ev.preventDefault()
+    }
+
     window.revealNextCloze = function() {
       revealNextClozeOf(revealNextClozeMode)
+    }
+
+    window.toggleAllCloze = function() {
+      let elems = document.querySelectorAll(".cloze-hidden")
+      if(elems.length > 0) {
+        for (const elem of elems) {
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
+        }
+      } else {
+        hideAllCloze(initial=false)
+      }
+    }
+
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
     }
 
     /**
@@ -151,62 +208,6 @@ _%>
       }
     }
 
-    const hideAllCloze = function(initial) {
-      let clozes = document.getElementsByClassName("cloze")
-      let count = 0 // hidden cloze count
-      for (const cloze of clozes) {
-        const existingHidden = cloze.getElementsByClassName("cloze-hidden")[0]
-        if (existingHidden) {
-          revealCloze(cloze);
-        }
-        if (cloze.offsetWidth === 0) {
-          continue
-        }
-        const clozeReplacer = document.createElement("span")
-        const clozeHidden = document.createElement("span")
-        clozeReplacer.classList.add("cloze-replacer")
-        clozeHidden.classList.add("cloze-hidden")
-        clozeReplacer.innerHTML = clozeHider(cloze)
-        while (cloze.childNodes.length > 0) {
-          clozeHidden.appendChild(cloze.childNodes[0])
-        }
-        cloze.appendChild(clozeReplacer)
-        cloze.appendChild(clozeHidden)
-
-        if (window.clozeHints && window.clozeHints[count]) {
-          clozeReplacer.classList.add("cloze-hint")
-          clozeReplacer.innerHTML = window.clozeHints[count]
-        }
-        count += 1
-        if (initial) {
-          cloze.addEventListener("touchend", revealClozeClicked)
-          cloze.addEventListener("click", revealClozeClicked)
-        }
-      }
-    }
-
-    window.toggleAllCloze = function() {
-      let elems = document.querySelectorAll(".cloze-hidden")
-      if(elems.length > 0) {
-        for (const elem of elems) {
-          const cloze = clozeElOfClozeHidden(elem)
-          revealCloze(cloze)
-        }
-      } else {
-        hideAllCloze(initial=false)
-      }
-    }
-
-    const revealClozeClicked = function(ev) {
-      let elem = ev.currentTarget
-      if (!ev.altKey && (revealNextClozeMode !== "word")) {
-        revealCloze(elem)
-      } else {
-        revealClozeWord(elem)
-      }
-      ev.stopPropagation()
-      ev.preventDefault()
-    }      
 
     hideAllCloze(initial=true)
 

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -62,7 +62,7 @@ _%>
 
       cloze.removeChild(clozeReplacer)
       cloze.removeChild(clozeHidden)
-      for(const child of clozeHidden) {
+      for(const child of clozeHidden.childNodes) {
         cloze.appendChild(child)
       }
       rerunMathJax() // Is this still needed?
@@ -95,20 +95,30 @@ _%>
       rerunMathJax()
     }
 
-    window.revealNextCloze = function() {
+    const clozeElOfClozeHidden = (cloze) => {
+      while (!cloze.classList.contains("cloze")) {
+        cloze = cloze.parentElement;
+      }
+      return cloze;
+    }
+
+    const revealNextClozeOf = (type) => {
       const nextHidden = document.querySelector(".cloze-hidden")
       if(!nextHidden) {
           return
       } 
-      let cloze = nextHidden;
-      while (!cloze.classList.contains("cloze")) {
-        cloze = cloze.parentElement;
-      }
-      if (revealNextClozeMode === "word") {
+      const cloze = clozeElOfClozeHidden(nextHidden);
+      if (type === "word") {
           revealClozeWord(cloze)
-      } else {
+      } else if (type === "cloze") {
           revealCloze(cloze)
+      } else {
+        console.error("Invalid type: " + type)
       }
+    }
+
+    window.revealNextCloze = function() {
+      revealNextClozeOf(revealNextClozeMode)
     }
 
     /**
@@ -131,7 +141,7 @@ _%>
           return false;
         }
       } else {
-        for (const child of node.children) {
+        for (const child of node.childNodes) {
           if (setRangeEndToFirstSpace(range, child)) {
             return true;
           }
@@ -174,7 +184,8 @@ _%>
       let elems = document.querySelectorAll(".cloze-hidden")
       if(elems.length > 0) {
         for (const elem of elems) {
-          elem.classList.remove("hidden");
+          const cloze = clozeElOfClozeHidden(elem)
+          revealCloze(cloze)
         }
       } else {
         hideAllCloze(initial=false)
@@ -183,9 +194,6 @@ _%>
 
     const revealClozeClicked = function(ev) {
       let elem = ev.currentTarget
-      if (elem.dataset.content === undefined) {
-        return
-      }
       if (!ev.altKey && (revealNextClozeMode !== "word")) {
         revealCloze(elem)
       } else {
@@ -216,22 +224,17 @@ _%>
       let next = isShowNextShortcut(ev)
       let word = isShowWordShortcut(ev)
       let all = isToggleAllShortcut(ev)
-      if (next || word) {
-        let elem = document.querySelector(".cloze[data-content]")
-        if (elem) {
-          if (next) {
-            revealCloze(elem)
-          } else {
-            revealClozeWord(elem)
-          }
-          ev.stopPropagation()
-          ev.preventDefault()
-        }
+      if (next) {
+        revealNextClozeOf("cloze")
+      } else if (word) {
+        revealNextClozeOf("word")
       } else if (all) {
         toggleAllCloze()
-        ev.stopPropagation()
-        ev.preventDefault()
+      } else {
+        return;
       }
+      ev.stopPropagation()
+      ev.preventDefault()
     });
   })()
 </script>

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -73,24 +73,27 @@ _%>
       const clozeHidden = cloze.getElementsByClassName("cloze-hidden")[0]
       if (!clozeReplacer || !clozeHidden) return;
 
-      const range = new Range()
+      let range = new Range()
       range.setStart(clozeHidden, 0)
-      let enable = true
-      while(enable) {
-        const found = setRangeEndToFirstSpace(range, clozeHidden)
-        if (!found) {
-          range.setEnd(clozeHidden, clozeHidden.childNodes.length)
-        }
-        const onlyWhitespace = /^\s*$/.test(range.toString())
-        enable = found && onlyWhitespace
-
-        const fragment = range.extractContents()
+      const whitespaces = setRangeEndToAfterLastSpace(range, clozeHidden);
+      if (whitespaces) {
+        const fragment = range.extractContents();
         cloze.insertBefore(fragment, clozeReplacer)
+      }
+
+      range = new Range()
+      range.setStart(clozeHidden, 0)
+      const found = setRangeEndToBeforeFirstSpace(range, clozeHidden)
+      if (!found) {
+        range.setEnd(clozeHidden, clozeHidden.childNodes.length)
+      }
+      const fragment = range.extractContents()
+      cloze.insertBefore(fragment, clozeReplacer)
+      if (found) {
         clozeReplacer.innerHTML = clozeHider(clozeHidden)
-        if (!found) {
-          cloze.removeChild(clozeHidden)
-          cloze.removeChild(clozeReplacer)
-        }
+      } else {
+        cloze.removeChild(clozeHidden)
+        cloze.removeChild(clozeReplacer)
       }
       rerunMathJax()
     }
@@ -122,27 +125,39 @@ _%>
     }
 
     /**
-     * Call range.setEnd() to before first whitespace character in node.
      * Return `true` whitespace exists and setEnd() was called, otherwise `false`
      */
-    const setRangeEndToFirstSpace = function(range, node) {
+    const setRangeEndToBeforeFirstSpace = function(range, node) {
       if (node.nodeType === Node.TEXT_NODE) {
-        let firstWhitespace = -1;
-        for (const whitespace of [" ", "\n", "\t"]) {
-          const index = text.indexOf(whitespace);
-          if (index !== -1 && (firstWhitespace === -1 || index < firstWhitespace)) {
-            firstWhitespace = index;
-          }
-        }
-        if (firstWhitespace !== -1) {
-          range.setEnd(node, firstWhitespace);
+        const match = node.wholeText.match(/\s/)
+        if (match) {
+          range.setEnd(node, match.index);
           return true;
         } else {
           return false;
         }
       } else {
         for (const child of node.childNodes) {
-          if (setRangeEndToFirstSpace(range, child)) {
+          if (setRangeEndToBeforeFirstSpace(range, child)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    }
+
+    const setRangeEndToAfterLastSpace = function(range, node) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const match = node.wholeText.match(/\S/)
+        if (match) {
+          range.setEnd(node, match.index);
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        for (const child of node.childNodes) {
+          if (setRangeEndToAfterLastSpace(range, child)) {
             return true;
           }
         }

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -189,7 +189,7 @@ _%>
      */
     const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const regex = mode === 'beforeFirstSpace' ? /\s/ : /\S/
         const match = node.textContent.match(regex)
         if (match) {
           range.setEnd(node, match.index);
@@ -197,6 +197,9 @@ _%>
         } else {
           return false;
         }
+      } else if (mode === 'afterLastSpace' && isWordNode(node)) {
+        range.setEndBefore(node)
+        return true
       } else if (!ignoreSpaceInNode(node)) {
         for (const child of node.childNodes) {
           if (setRangeEnd(range, child, mode)) {
@@ -211,6 +214,9 @@ _%>
       return node.tagName === "MJX-ASSISTIVE-MML"
     }
 
+    const isWordNode = function(node) {
+      return node.tagName in ["IMG", "MJX-CONTAINER"]
+    }
 
     hideAllCloze(initial=true)
 

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -62,7 +62,7 @@ _%>
 
       cloze.removeChild(clozeReplacer)
       cloze.removeChild(clozeHidden)
-      while (clozeHidden.children.length > 0) {
+      while (clozeHidden.childNodes.length > 0) {
         cloze.appendChild(clozeHidden.childNodes[0])
       }
       rerunMathJax() // Is this still needed?

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -62,8 +62,8 @@ _%>
 
       cloze.removeChild(clozeReplacer)
       cloze.removeChild(clozeHidden)
-      for(const child of clozeHidden.childNodes) {
-        cloze.appendChild(child)
+      while (clozeHidden.children.length > 0) {
+        cloze.appendChild(clozeHidden.childNodes[0])
       }
       rerunMathJax() // Is this still needed?
     }
@@ -177,8 +177,8 @@ _%>
         clozeReplacer.classList.add("cloze-replacer")
         clozeHidden.classList.add("cloze-hidden")
         clozeReplacer.innerHTML = clozeHider(cloze)
-        for(const child of cloze.childNodes) {
-          clozeHidden.appendChild(child);
+        while (cloze.childNodes.length > 0) {
+          clozeHidden.appendChild(cloze.childNodes[0])
         }
         cloze.appendChild(clozeReplacer)
         cloze.appendChild(clozeHidden)

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -74,7 +74,7 @@ _%>
 
       let range = new Range()
       range.setStart(clozeHidden, 0)
-      const foundSpace = setRangeEndToBeforeFirstSpace(range, clozeHidden)
+      const foundSpace = setRangeEnd(range, clozeHidden, "beforeFirstSpace")
       if (!foundSpace) {
         range.setEnd(clozeHidden, clozeHidden.childNodes.length)
       }
@@ -83,7 +83,7 @@ _%>
       // Extract whitespaces after word
       range = new Range()
       range.setStart(clozeHidden, 0)
-      const foundWord = setRangeEndToAfterLastSpace(range, clozeHidden);
+      const foundWord = setRangeEnd(range, clozeHidden, "afterLastSpace")
       if (!foundWord) {
         range.setEnd(clozeHidden, clozeHidden.childNodes.length)
       }    
@@ -128,11 +128,13 @@ _%>
     }
 
     /**
-     * Return `true` whitespace exists and setEnd() was called, otherwise `false`
+     * mode: 'beforeFirstSpace' or 'afterLastSpace'
+     * Return `true` if it exists and setEnd() was called, otherwise `false`
      */
-    const setRangeEndToBeforeFirstSpace = function(range, node) {
+    const setRangeEnd = function(range, node, mode) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const match = node.textContent.match(/\s/)
+        const regex = mode == 'beforeFirstSpace' ? /\s/ : /\S/
+        const match = node.textContent.match(regex)
         if (match) {
           range.setEnd(node, match.index);
           return true;
@@ -141,26 +143,7 @@ _%>
         }
       } else {
         for (const child of node.childNodes) {
-          if (setRangeEndToBeforeFirstSpace(range, child)) {
-            return true;
-          }
-        }
-        return false;
-      }
-    }
-
-    const setRangeEndToAfterLastSpace = function(range, node) {
-      if (node.nodeType === Node.TEXT_NODE) {
-        const match = node.textContent.match(/\S/)
-        if (match) {
-          range.setEnd(node, match.index);
-          return true;
-        } else {
-          return false;
-        }
-      } else {
-        for (const child of node.childNodes) {
-          if (setRangeEndToAfterLastSpace(range, child)) {
+          if (setRangeEnd(range, child, mode)) {
             return true;
           }
         }

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -222,7 +222,7 @@ _%>
     }
 
     const isWordNode = function(node) {
-      return node.tagName in ["IMG", "MJX-CONTAINER"]
+      return ["IMG", "MJX-CONTAINER"].includes(node.tagName)
     }
 
     hideAllCloze(initial=true)

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -129,7 +129,7 @@ _%>
      */
     const setRangeEndToBeforeFirstSpace = function(range, node) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const match = node.wholeText.match(/\s/)
+        const match = node.textContent.match(/\s/)
         if (match) {
           range.setEnd(node, match.index);
           return true;
@@ -148,7 +148,7 @@ _%>
 
     const setRangeEndToAfterLastSpace = function(range, node) {
       if (node.nodeType === Node.TEXT_NODE) {
-        const match = node.wholeText.match(/\S/)
+        const match = node.textContent.match(/\S/)
         if (match) {
           range.setEnd(node, match.index);
           return true;


### PR DESCRIPTION
Fixes #95, #58

Clozes that has HTML elements should work much better.

The exposed api is not modified, but everything else in `clozeOneByOneBack.ejs` was mostly rewritten.

Could you check if there's no problem with other add-ons or cases that I haven't thought of?
I've checked that it works fine with 1) Mathjax 2) Images 3) AMBOSS in cloze content in AnkingOverhaul note type. 

AMBOSS for cloze hints disappear after revealing then hiding, but I think the problem is minor enough that adding more complexity for it is not worth it.