### PR TITLE
Preserve shuffled cloze order on back

### DIFF
--- a/Note Types/AnKing MCAT/Back Template.html
+++ b/Note Types/AnKing MCAT/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKing MCAT/Front Template.html
+++ b/Note Types/AnKing MCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingAnkisthesia/Back Template.html
+++ b/Note Types/AnKingAnkisthesia/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 

--- a/Note Types/AnKingAnkisthesia/Front Template.html
+++ b/Note Types/AnKingAnkisthesia/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 <!-- ##############  Text-to-speech  ##############

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -1115,7 +1115,7 @@ var userJs8 = undefined
     (() => {
         const selectors = [".shuffle", "#dermpath,#dermoscopy,#visualdx,#dermnet,#fullspectrum,#additional"];
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -1136,14 +1136,39 @@ var userJs8 = undefined
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -1159,7 +1184,7 @@ var userJs8 = undefined
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -1220,11 +1245,12 @@ var userJs8 = undefined
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -1249,7 +1275,7 @@ var userJs8 = undefined
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {
@@ -1265,4 +1291,3 @@ var userJs8 = undefined
 </script>
 
 <!-- END WRAPPER CODE -->
-

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -300,7 +300,7 @@ if (typeof(window.Persistence) === 'undefined') {
     (() => {
         const selectors = [".shuffle"];
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -321,14 +321,39 @@ if (typeof(window.Persistence) === 'undefined') {
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -344,7 +369,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -405,11 +430,12 @@ if (typeof(window.Persistence) === 'undefined') {
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -434,7 +460,7 @@ if (typeof(window.Persistence) === 'undefined') {
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {

--- a/Note Types/AnKingDermPath/Back Template.html
+++ b/Note Types/AnKingDermPath/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -727,7 +727,7 @@ var userJs8 = undefined
     (() => {
         const selectors = [".shuffle", "#front,#clinical,#dermoscopy,#visualdx,#dermnet,#fullspectrum,#additional"];
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -748,14 +748,39 @@ var userJs8 = undefined
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -771,7 +796,7 @@ var userJs8 = undefined
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -832,11 +857,12 @@ var userJs8 = undefined
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -861,7 +887,7 @@ var userJs8 = undefined
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {
@@ -877,4 +903,3 @@ var userJs8 = undefined
 </script>
 
 <!-- END WRAPPER CODE -->
-

--- a/Note Types/AnKingDermPath/Front Template.html
+++ b/Note Types/AnKingDermPath/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="front">{{edit:Front}}</div>
 <div style="font-size:8px; font-style:italic;">Above Image(s) provided courtesy of Tammie Ferringer, MD</div>
 
@@ -361,7 +361,7 @@ if (typeof(window.Persistence) === 'undefined') {
     (() => {
         const selectors = [".shuffle", "#front"];
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -382,14 +382,39 @@ if (typeof(window.Persistence) === 'undefined') {
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -405,7 +430,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -466,11 +491,12 @@ if (typeof(window.Persistence) === 'undefined') {
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -495,7 +521,7 @@ if (typeof(window.Persistence) === 'undefined') {
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -1301,7 +1301,7 @@ var userJs8 = undefined
     (() => {
         const selectors = [".shuffle"];
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -1322,14 +1322,39 @@ var userJs8 = undefined
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -1345,7 +1370,7 @@ var userJs8 = undefined
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -1406,11 +1431,12 @@ var userJs8 = undefined
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -1435,7 +1461,7 @@ var userJs8 = undefined
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -371,7 +371,7 @@ if (typeof(window.Persistence) === 'undefined') {
     (() => {
         const selectors = [".shuffle"];
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -392,14 +392,39 @@ if (typeof(window.Persistence) === 'undefined') {
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -415,7 +440,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -476,11 +501,12 @@ if (typeof(window.Persistence) === 'undefined') {
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -505,7 +531,7 @@ if (typeof(window.Persistence) === 'undefined') {
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {

--- a/Note Types/AnKingOverlapping/Back Template.html
+++ b/Note Types/AnKingOverlapping/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on

--- a/Note Types/AnKingOverlapping/Front Template.html
+++ b/Note Types/AnKingOverlapping/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 52edd71 -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/src/components/shuffleItems.ejs
+++ b/src/components/shuffleItems.ejs
@@ -18,7 +18,7 @@ _%>
         const selectors = [".shuffle"];
         <%_ } _%>
         const shuffleMap = Persistence.getItem("shuffle") || {};
-        const shuffledWordClass = "shuffled-word";
+        const containerSelector = selectors.join(", ");
 
         function isFront() {
             const hasHrMarker = document.querySelector("hr[id=answer]");
@@ -39,14 +39,39 @@ _%>
             }
         }
 
-        function shuffleElements(elements) {
+        function getNearestIdElement(element) {
+            let current = element;
+            while (current && current !== document.body) {
+                if (current.id) {
+                    return current;
+                }
+                current = current.parentElement;
+            }
+            return null;
+        }
+
+        function getScopedIndex(element, selector) {
+            const scope = getNearestIdElement(element);
+            const candidates = scope
+                ? Array.from(scope.querySelectorAll(selector))
+                : Array.from(document.querySelectorAll(selector));
+            const index = candidates.indexOf(element);
+            return index === -1 ? 0 : index;
+        }
+
+        function shuffleKey(element, groupType, selector) {
+            const scope = getNearestIdElement(element);
+            const scopeKey = scope ? `${scope.tagName.toLowerCase()}#${scope.id}` : "document";
+            const index = selector ? getScopedIndex(element, selector) : 0;
+            return `${scopeKey}:${groupType}:${index}`;
+        }
+
+        function shuffleElements(elements, mapKey) {
             elements = elements.filter(e => !e.matches(".no-shuffle *"));
             if (elements.length === 0) {
                 return;
             }
             const shuffledElements = Array.from(elements);
-            // Assuming elements[0] is not also the first element in a different list to shuffle
-            const mapKey = shuffledElements[0];
             const indexMap = shuffleMap[mapKey] || {};
             elements = elements.map(el => {
                 const placeholder = document.createTextNode('');
@@ -62,7 +87,7 @@ _%>
 
         function shuffleList(listElement) {
             const items = Array.from(listElement.querySelectorAll("li"));
-            shuffleElements(items);
+            shuffleElements(items, shuffleKey(listElement, "list", "ol, ul"));
         }
 
         /**
@@ -123,11 +148,12 @@ _%>
                 return item.replace(/,\s*(?=<\/|$)/g, '');
             });
 
-            const indexMap = shuffleMap[element] || {};
+            const mapKey = shuffleKey(element, "sentence", ".shuffle-sentence");
+            const indexMap = shuffleMap[mapKey] || {};
 
             const itemsToShuffle = [...cleanedItems];
             shuffle(itemsToShuffle, indexMap);
-            shuffleMap[element] = indexMap;
+            shuffleMap[mapKey] = indexMap;
 
             let newHTML;
             if (itemsToShuffle.length === 2) {
@@ -152,7 +178,7 @@ _%>
                     shuffleList(parentElement);
                 }
                 const images = Array.from(container.querySelectorAll("img"));
-                shuffleElements(images);
+                shuffleElements(images, shuffleKey(container, "images", containerSelector));
             }
         }
         for (const element of document.querySelectorAll(".shuffle-sentence")) {

--- a/src/notetypes/AnKingDerm/back.ejs
+++ b/src/notetypes/AnKingDerm/back.ejs
@@ -120,4 +120,4 @@ replace the arrows/dashes from the statement below with double curly brackets-->
 
 <%- include('src/components/imageBlur.ejs') %>
 
-<%- include('src/components/shuffleItems.ejs', {selector: "#dermpath,#dermoscopy,#visualdx,#dermnet,#fullspectrum,#additional"}) %>
+<%- include('src/components/shuffleItems.ejs', {selector: "#dermpath,#dermoscopy,#visualdx,#dermnet,#fullspectrum,#additional"}) -%>

--- a/src/notetypes/AnKingDermPath/back.ejs
+++ b/src/notetypes/AnKingDermPath/back.ejs
@@ -98,4 +98,4 @@ var ScrollToButton = true;
 
 <%- include('src/components/imageBlur.ejs') %>
 
-<%- include('src/components/shuffleItems.ejs', {selector: "#front,#clinical,#dermoscopy,#visualdx,#dermnet,#fullspectrum,#additional"}) %>
+<%- include('src/components/shuffleItems.ejs', {selector: "#front,#clinical,#dermoscopy,#visualdx,#dermnet,#fullspectrum,#additional"}) -%>


### PR DESCRIPTION
## Summary
- Persist shuffle state with stable string keys instead of DOM element object keys.
- Preserve randomized cloze/list/image order when flipping from front to back.
- Regenerate note type templates from src via the repo build process.

## Root Cause
The shuffle map used DOM elements as object keys. Front and back card renders use separate DOMs, so the back side could miss the original shuffle map and generate or apply a different order.

## Validation
- npm run build
- git diff --check origin/master..HEAD
- Parsed generated shuffle scripts with new Function(...)
- Ran a focused replay check for duplicate cloze fields sharing the same stable shuffle keys