### PR TITLE
Fix calculation of minimum number of clozes for one by one

### DIFF
--- a/Note Types/AnKing MCAT/Back Template.html
+++ b/Note Types/AnKing MCAT/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -524,7 +524,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -553,11 +553,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKing MCAT/Back Template.html
+++ b/Note Types/AnKing MCAT/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -553,11 +553,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKing MCAT/Back Template.html
+++ b/Note Types/AnKing MCAT/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKing MCAT/Front Template.html
+++ b/Note Types/AnKing MCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -243,7 +243,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKing MCAT/Front Template.html
+++ b/Note Types/AnKing MCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -195,7 +195,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -239,11 +239,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKing MCAT/Front Template.html
+++ b/Note Types/AnKing MCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -520,11 +520,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -491,7 +491,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -520,11 +520,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -195,7 +195,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -239,11 +239,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -243,7 +243,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingAnkisthesia/Back Template.html
+++ b/Note Types/AnKingAnkisthesia/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
@@ -534,7 +534,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -563,11 +563,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKingAnkisthesia/Back Template.html
+++ b/Note Types/AnKingAnkisthesia/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 

--- a/Note Types/AnKingAnkisthesia/Back Template.html
+++ b/Note Types/AnKingAnkisthesia/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // Visit https://keycode.info/ to get the number/letter for the key you want to assign. 
@@ -563,11 +563,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKingAnkisthesia/Front Template.html
+++ b/Note Types/AnKingAnkisthesia/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 <!-- ##############  Text-to-speech  ##############
@@ -193,7 +193,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -237,11 +237,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKingAnkisthesia/Front Template.html
+++ b/Note Types/AnKingAnkisthesia/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 <!-- ##############  Text-to-speech  ##############

--- a/Note Types/AnKingAnkisthesia/Front Template.html
+++ b/Note Types/AnKingAnkisthesia/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 <!-- ##############  Text-to-speech  ##############
@@ -241,7 +241,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -590,7 +590,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -619,11 +619,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -619,11 +619,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -196,7 +196,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -240,11 +240,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -244,7 +244,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 

--- a/Note Types/AnKingDermPath/Back Template.html
+++ b/Note Types/AnKingDermPath/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingDermPath/Back Template.html
+++ b/Note Types/AnKingDermPath/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingDermPath/Back Template.html
+++ b/Note Types/AnKingDermPath/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingDermPath/Front Template.html
+++ b/Note Types/AnKingDermPath/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="front">{{edit:Front}}</div>
 <div style="font-size:8px; font-style:italic;">Above Image(s) provided courtesy of Tammie Ferringer, MD</div>
 

--- a/Note Types/AnKingDermPath/Front Template.html
+++ b/Note Types/AnKingDermPath/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="front">{{edit:Front}}</div>
 <div style="font-size:8px; font-style:italic;">Above Image(s) provided courtesy of Tammie Ferringer, MD</div>
 

--- a/Note Types/AnKingDermPath/Front Template.html
+++ b/Note Types/AnKingDermPath/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="front">{{edit:Front}}</div>
 <div style="font-size:8px; font-style:italic;">Above Image(s) provided courtesy of Tammie Ferringer, MD</div>
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -776,7 +776,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -805,11 +805,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -805,11 +805,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -195,7 +195,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -239,11 +239,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -243,7 +243,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverlapping/Back Template.html
+++ b/Note Types/AnKingOverlapping/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on

--- a/Note Types/AnKingOverlapping/Back Template.html
+++ b/Note Types/AnKingOverlapping/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on

--- a/Note Types/AnKingOverlapping/Back Template.html
+++ b/Note Types/AnKingOverlapping/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
   // ##############  HINT REVEAL SHORTCUTS  ##############
   // All shortcuts will also open with "H" if using the Hint Hotkeys add-on

--- a/Note Types/AnKingOverlapping/Front Template.html
+++ b/Note Types/AnKingOverlapping/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverlapping/Front Template.html
+++ b/Note Types/AnKingOverlapping/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/AnKingOverlapping/Front Template.html
+++ b/Note Types/AnKingOverlapping/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="front">{{edit:Front}}</div>
 
 <br>

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -532,11 +532,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -503,7 +503,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -532,11 +532,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -194,7 +194,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -238,11 +238,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -242,7 +242,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -539,11 +539,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -510,7 +510,7 @@ if (typeof(window.Persistence) === 'undefined') {
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -539,11 +539,11 @@ if (typeof(window.Persistence) === 'undefined') {
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 450771e -->
+<!-- version 82fedac -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -194,7 +194,7 @@ if (typeof(window.Persistence) === 'undefined') {
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";
@@ -238,11 +238,11 @@ if (typeof(window.Persistence) === 'undefined') {
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version d10be55 -->
+<!-- version 3d9b0dd -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -242,7 +242,7 @@ if (typeof(window.Persistence) === 'undefined') {
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version 3d9b0dd -->
+<!-- version 450771e -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -84,11 +84,11 @@ _%>
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
+    var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -53,7 +53,7 @@ _%>
   (function() {
     // enables cloze one-by-one even when one-by-one field is empty
     // minNumberOfClozes is still considered in this case
-    // overridden in importance by selectiveOneByOne
+    // overridden in importance by selectiveOneByOne and minNumberOfClozes
     var alwaysOneByOne = false;
     var clozeOneByOneEnabled = true;
     var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -84,7 +84,7 @@ _%>
     var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
     // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+    var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.clozefield .cloze').length : 0
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -88,7 +88,7 @@ _%>
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+    if (selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes) {
       clozeOneByOneEnabled = false
     }
 

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -88,7 +88,7 @@ _%>
 
     // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
     // -> show normal backside
-    if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+    if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
       clozeOneByOneEnabled = false
     }
 

--- a/src/components/clozeOneByOneFront.ejs
+++ b/src/components/clozeOneByOneFront.ejs
@@ -76,7 +76,7 @@ _%>
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/src/components/clozeOneByOneFront.ejs
+++ b/src/components/clozeOneByOneFront.ejs
@@ -26,7 +26,7 @@ _%>
 <script>
   // enables cloze one-by-one even when one-by-one field is empty
   // minNumberOfClozes is still considered in this case
-  // overridden in importance by selectiveOneByOne
+  // overridden in importance by selectiveOneByOne and minNumberOfClozes
   var alwaysOneByOne = false;
   var clozeOneByOneEnabled = true;
   var oneByOneFieldNotEmpty = document.getElementById("one-by-one").textContent !== "";

--- a/src/components/clozeOneByOneFront.ejs
+++ b/src/components/clozeOneByOneFront.ejs
@@ -72,11 +72,11 @@ _%>
       var cardNumberIsOneByOne = !clozeNumbers.filter(n => !Number.isNaN(n)).length || clozeNumbers.includes(parseInt(getCardNumber()))
 
       // check the amount of clozes -> disable OneByOne if less than minimum value wanted (minNumberOfClozes)
-      var numClozesForNumber = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
+      var numClozes = (minNumberOfClozes) ? document.querySelectorAll('.cloze').length : 0
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes) {
+      if (selectiveOneByOne && !cardNumberIsOneByOne || numClozes < minNumberOfClozes) {
         clozeOneByOneEnabled = false
       }
 

--- a/src/components/clozeOneByOneFront.ejs
+++ b/src/components/clozeOneByOneFront.ejs
@@ -76,7 +76,7 @@ _%>
 
       // stop OneByOne if selectiveOneByOne is not enabled for this specific card OR if OneByOne is disabled some other way
       // -> show normal backside
-      if (!alwaysOneByOne && ((selectiveOneByOne && !cardNumberIsOneByOne) || (oneByOneFieldNotEmpty && (numClozesForNumber < minNumberOfClozes)))) {
+      if ((selectiveOneByOne && !cardNumberIsOneByOne || numClozesForNumber < minNumberOfClozes)) {
         clozeOneByOneEnabled = false
       }
 


### PR DESCRIPTION
This fixes some issues with calculation of minimum number of clozes to enable one by one:
1. `numClozesForNumber` on the back side was also counting clozes inside `{{edit:cloze:Text}}`, resulting in double counts.
2. `alwaysOneByOne` was overriding `numClozesForNumber`. Having it the other way around is more flexible.

See report: https://community.ankihub.net/t/onebyone-always-on-if-clozes-2-is-not-working/586234

